### PR TITLE
Add PL Day archive feature with navigation integration

### DIFF
--- a/app/Http/Controllers/Admin/PDDayController.php
+++ b/app/Http/Controllers/Admin/PDDayController.php
@@ -44,9 +44,11 @@ class PDDayController extends Controller
             'academic_year' => 'nullable|string|max:9|regex:/^\d{4}-\d{4}$/',
         ]);
 
-        // If setting this as active, deactivate all others
-        if ($request->boolean('is_active')) {
-            PDDay::where('is_active', true)->update(['is_active' => false]);
+        // If setting this as active, deactivate others of the same season
+        if ($request->boolean('is_active') && $validated['season']) {
+            PDDay::where('is_active', true)
+                ->where('season', $validated['season'])
+                ->update(['is_active' => false]);
         }
 
         PDDay::create($validated);
@@ -61,6 +63,13 @@ class PDDayController extends Controller
      */
     public function edit(PDDay $pdday)
     {
+        // Block editing of archived PL Days
+        if ($pdday->isArchived()) {
+            return redirect()
+                ->route('admin.pddays.index')
+                ->with('error', 'Archived PL Days cannot be edited. Please unarchive first.');
+        }
+
         return view('admin.pddays.edit', compact('pdday'));
     }
 
@@ -79,9 +88,12 @@ class PDDayController extends Controller
             'academic_year' => 'nullable|string|max:9|regex:/^\d{4}-\d{4}$/',
         ]);
 
-        // If setting this as active, deactivate all others
-        if ($request->boolean('is_active') && !$pdday->is_active) {
-            PDDay::where('is_active', true)->update(['is_active' => false]);
+        // If setting this as active, deactivate others of the same season
+        $season = $validated['season'] ?? $pdday->season;
+        if ($request->boolean('is_active') && ! $pdday->is_active && $season) {
+            PDDay::where('is_active', true)
+                ->where('season', $season)
+                ->update(['is_active' => false]);
         }
 
         $pdday->update($validated);
@@ -96,10 +108,21 @@ class PDDayController extends Controller
      */
     public function toggleActive(PDDay $pdday)
     {
+        // Block activating archived PL Days
+        if ($pdday->isArchived()) {
+            return redirect()
+                ->back()
+                ->with('error', 'Archived PL Days cannot be activated. Please unarchive first.');
+        }
+
         DB::transaction(function () use ($pdday) {
-            if (!$pdday->is_active) {
-                // Deactivate all other PD days
-                PDDay::where('is_active', true)->update(['is_active' => false]);
+            if (! $pdday->is_active) {
+                // Deactivate other PD days of the same season
+                if ($pdday->season) {
+                    PDDay::where('is_active', true)
+                        ->where('season', $pdday->season)
+                        ->update(['is_active' => false]);
+                }
                 $pdday->update(['is_active' => true]);
             } else {
                 $pdday->update(['is_active' => false]);
@@ -120,7 +143,7 @@ class PDDayController extends Controller
     {
         // Check if there are any associated sessions
         $sessionsCount = $pdday->scheduleItems()->count() + $pdday->wellnessSessions()->count();
-        
+
         if ($sessionsCount > 0) {
             return redirect()
                 ->back()
@@ -132,5 +155,48 @@ class PDDayController extends Controller
         return redirect()
             ->route('admin.pddays.index')
             ->with('success', 'PL Day deleted successfully.');
+    }
+
+    /**
+     * Archive a PD day
+     */
+    public function archive(PDDay $pdday)
+    {
+        // PL Day must be inactive to be archived
+        if ($pdday->is_active) {
+            return redirect()
+                ->back()
+                ->with('error', 'Cannot archive an active PL Day. Please deactivate it first.');
+        }
+
+        if ($pdday->isArchived()) {
+            return redirect()
+                ->back()
+                ->with('error', 'This PL Day is already archived.');
+        }
+
+        $pdday->archive();
+
+        return redirect()
+            ->back()
+            ->with('success', 'PL Day archived successfully.');
+    }
+
+    /**
+     * Unarchive a PD day
+     */
+    public function unarchive(PDDay $pdday)
+    {
+        if (! $pdday->isArchived()) {
+            return redirect()
+                ->back()
+                ->with('error', 'This PL Day is not archived.');
+        }
+
+        $pdday->unarchive();
+
+        return redirect()
+            ->back()
+            ->with('success', 'PL Day unarchived successfully.');
     }
 }

--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Models\ScheduleItem;
 use App\Models\Division;
 use App\Models\PDDay;
-use App\Models\PLWednesdaySetting;
 use App\Models\PLDaysSetting;
+use App\Models\PLWednesdaySetting;
+use App\Models\ScheduleItem;
 use Carbon\Carbon;
+use Illuminate\Http\Request;
 
 class ScheduleController extends Controller
 {
@@ -20,19 +20,19 @@ class ScheduleController extends Controller
         // Initialize settings
         PLDaysSetting::initialize();
         PLWednesdaySetting::initialize();
-        
+
         // Check if PL Days feature is enabled
-        if (!PLDaysSetting::isActive()) {
+        if (! PLDaysSetting::isActive()) {
             // Redirect to PL Wednesday as fallback
             return redirect()->route('pl-wednesday.index');
         }
 
-        $user = auth()->user(); 
+        $user = auth()->user();
         $divisions = Division::active()->get();
-        
+
         // Get active PD Day
         $activePDDay = PDDay::getActive();
-        
+
         // Check if there are any active schedule items in PL Days
         $hasActivePLDaysSessions = false;
         if ($activePDDay) {
@@ -40,32 +40,32 @@ class ScheduleController extends Controller
                 ->where('p_d_day_id', $activePDDay->id)
                 ->exists();
         }
-        
+
         // If no active PD Day or no active sessions, redirect to PL Wednesday
-        if (!$activePDDay || !$hasActivePLDaysSessions) {
+        if (! $activePDDay || ! $hasActivePLDaysSessions) {
             return redirect()->route('pl-wednesday.index');
         }
-        
+
         // Generate date range from PD Day if available
         $eventDates = [];
         if ($activePDDay) {
             $start = Carbon::parse($activePDDay->start_date);
             $end = Carbon::parse($activePDDay->end_date);
-            
+
             while ($start->lte($end)) {
                 $eventDates[] = $start->copy();
                 $start->addDay();
             }
         }
-        
+
         // Get active tab (default to Day 1)
         $activeTab = $request->get('day', 'day1');
         $dayIndex = (int) str_replace('day', '', $activeTab) - 1;
         $selectedDate = $eventDates[$dayIndex] ?? null;
-        
+
         // Get division filter preference (default to all divisions for better UX)
         $selectedDivisions = $request->get('divisions', []);
-        
+
         // Handle checkbox filter
         if (empty($selectedDivisions)) {
             $allSchoolSelected = true;
@@ -74,16 +74,16 @@ class ScheduleController extends Controller
             $allSchoolSelected = false;
             $allDivisionsSelected = false;
         }
-        
+
         // Get schedule items for the selected date
         $scheduleItems = collect();
         if ($selectedDate && $activePDDay) {
             $scheduleItems = ScheduleItem::active()
                 ->where('p_d_day_id', $activePDDay->id)
                 ->whereDate('date', $selectedDate)
-                ->when($selectedDivisions, function($query) use ($selectedDivisions) {
+                ->when($selectedDivisions, function ($query) use ($selectedDivisions) {
                     // If specific divisions are selected, show items that are assigned to those divisions
-                    return $query->whereHas('divisions', function($subQ) use ($selectedDivisions) {
+                    return $query->whereHas('divisions', function ($subQ) use ($selectedDivisions) {
                         $subQ->whereIn('divisions.id', $selectedDivisions);
                     });
                 })
@@ -91,7 +91,7 @@ class ScheduleController extends Controller
                 ->orderBy('start_time')
                 ->get();
         }
-        
+
         // Handle wellness session replacement for Day 2
         $userWellnessSession = null;
         if ($activeTab === 'day2') {
@@ -100,19 +100,19 @@ class ScheduleController extends Controller
                 ->where('status', '!=', 'cancelled')
                 ->with('wellnessSession')
                 ->first();
-            
+
             if ($userWellnessEnrollment && $userWellnessEnrollment->wellnessSession) {
                 $userWellnessSession = $userWellnessEnrollment->wellnessSession;
-                
+
                 // Remove the "Community Culture and Wellbeing" session and replace with user's wellness session
-                $scheduleItems = $scheduleItems->filter(function($item) {
-                    return !str_contains(strtolower($item->title), 'community culture and wellbeing');
+                $scheduleItems = $scheduleItems->filter(function ($item) {
+                    return ! str_contains(strtolower($item->title), 'community culture and wellbeing');
                 });
-                
+
                 // Create wellness schedule item with proper Carbon datetime instances
                 $wellnessStartTime = Carbon::parse($userWellnessSession->start_time);
                 $wellnessEndTime = Carbon::parse($userWellnessSession->end_time);
-                
+
                 // Add the user's wellness session to the schedule items
                 $wellnessScheduleItem = new \App\Models\ScheduleItem([
                     'title' => $userWellnessSession->title,
@@ -129,22 +129,22 @@ class ScheduleController extends Controller
                     'equipment_needed' => $userWellnessSession->equipment_needed,
                     'special_requirements' => $userWellnessSession->special_requirements,
                     'is_active' => true,
-                    'session_type' => 'wellness'
+                    'session_type' => 'wellness',
                 ]);
-                
+
                 // Add wellness session to the collection
                 $scheduleItems->push($wellnessScheduleItem);
-                
+
                 // Re-sort by start_time chronologically (ensuring proper Carbon comparison)
-                $scheduleItems = $scheduleItems->sortBy(function($item) {
+                $scheduleItems = $scheduleItems->sortBy(function ($item) {
                     return $item->start_time ? $item->start_time->timestamp : 0;
                 })->values();
             }
         }
-        
+
         return view('schedule.index', compact(
             'user',
-            'divisions', 
+            'divisions',
             'selectedDivisions',
             'allDivisionsSelected',
             'allSchoolSelected',
@@ -163,84 +163,99 @@ class ScheduleController extends Controller
     {
         // Check if PL Days feature is enabled
         PLDaysSetting::initialize();
-        if (!PLDaysSetting::isActive()) {
+        if (! PLDaysSetting::isActive()) {
             abort(404);
         }
 
         $user = auth()->user();
-        
+
         // Load relationships
         $scheduleItem->load(['divisions']);
-        
+
         return view('schedule.show', compact('scheduleItem', 'user'));
     }
 
     /**
      * Display Fall PL Day schedule
      */
-    public function fallIndex(Request $request)
+    public function fallIndex(Request $request, ?PDDay $pdday = null)
     {
-        return $this->seasonIndex($request, 'fall');
+        return $this->seasonIndex($request, 'fall', $pdday);
     }
 
     /**
      * Display Spring PL Days schedule
      */
-    public function springIndex(Request $request)
+    public function springIndex(Request $request, ?PDDay $pdday = null)
     {
-        return $this->seasonIndex($request, 'spring');
+        return $this->seasonIndex($request, 'spring', $pdday);
     }
 
     /**
      * Display schedule for a specific season
      */
-    protected function seasonIndex(Request $request, string $season)
+    protected function seasonIndex(Request $request, string $season, ?PDDay $pdday = null)
     {
         PLDaysSetting::initialize();
         PLWednesdaySetting::initialize();
-        
-        if (!PLDaysSetting::isActive()) {
+
+        if (! PLDaysSetting::isActive()) {
             return redirect()->route('pl-wednesday.index');
         }
 
-        $user = auth()->user(); 
+        $user = auth()->user();
         $divisions = Division::active()->get();
-        
-        // Get active PD Day for this season
-        $activePDDay = PDDay::where('is_active', true)
+        $isArchiveView = false;
+
+        // If specific archived PD Day requested
+        if ($pdday && $pdday->exists && $pdday->isArchived() && $pdday->season === $season) {
+            $activePDDay = $pdday;
+            $isArchiveView = true;
+        } else {
+            // Get active PD Day for this season
+            $activePDDay = PDDay::where('is_active', true)
+                ->where('season', $season)
+                ->first();
+
+            // Fallback to any active PD day if season-specific not found
+            if (! $activePDDay) {
+                $activePDDay = PDDay::getActive();
+            }
+        }
+
+        // Get the current active PD Day for this season (for tabs)
+        $activePDDayForSeason = PDDay::where('is_active', true)
             ->where('season', $season)
             ->first();
-        
-        // Fallback to any active PD day if season-specific not found
-        if (!$activePDDay) {
-            $activePDDay = PDDay::getActive();
-        }
-        
+
+        // Get archived PL Days for this season (for year tabs)
+        $archivedPDDays = PDDay::getArchivedBySeason($season);
+
         $hasActivePLDaysSessions = false;
         if ($activePDDay) {
             $hasActivePLDaysSessions = ScheduleItem::active()
                 ->where('p_d_day_id', $activePDDay->id)
                 ->exists();
         }
-        
+
         // Generate date range
         $eventDates = [];
         if ($activePDDay) {
             $start = Carbon::parse($activePDDay->start_date);
             $end = Carbon::parse($activePDDay->end_date);
-            
+
             while ($start->lte($end)) {
                 $eventDates[] = $start->copy();
                 $start->addDay();
             }
         }
-        
+
         $activeTab = $request->get('day', 'day1');
         $dayIndex = (int) str_replace('day', '', $activeTab) - 1;
         $selectedDate = $eventDates[$dayIndex] ?? null;
-        
+
         $selectedDivisions = $request->get('divisions', []);
-        
+
         if (empty($selectedDivisions)) {
             $allSchoolSelected = true;
             $allDivisionsSelected = true;
@@ -248,14 +263,14 @@ class ScheduleController extends Controller
             $allSchoolSelected = false;
             $allDivisionsSelected = false;
         }
-        
+
         $scheduleItems = collect();
         if ($selectedDate && $activePDDay) {
             $scheduleItems = ScheduleItem::active()
                 ->where('p_d_day_id', $activePDDay->id)
                 ->whereDate('date', $selectedDate)
-                ->when($selectedDivisions, function($query) use ($selectedDivisions) {
-                    return $query->whereHas('divisions', function($subQ) use ($selectedDivisions) {
+                ->when($selectedDivisions, function ($query) use ($selectedDivisions) {
+                    return $query->whereHas('divisions', function ($subQ) use ($selectedDivisions) {
                         $subQ->whereIn('divisions.id', $selectedDivisions);
                     });
                 })
@@ -263,27 +278,27 @@ class ScheduleController extends Controller
                 ->orderBy('start_time')
                 ->get();
         }
-        
-        // Handle wellness session replacement
+
+        // Handle wellness session replacement (only for non-archive view)
         $userWellnessSession = null;
-        if ($activeTab === 'day2') {
+        if ($activeTab === 'day2' && ! $isArchiveView) {
             $userWellnessEnrollment = \App\Models\UserSession::where('user_id', $user->id)
                 ->whereNotNull('wellness_session_id')
                 ->where('status', '!=', 'cancelled')
                 ->with('wellnessSession')
                 ->first();
-            
+
             if ($userWellnessEnrollment && $userWellnessEnrollment->wellnessSession) {
                 $userWellnessSession = $userWellnessEnrollment->wellnessSession;
-                
-                $scheduleItems = $scheduleItems->filter(function($item) {
-                    return !str_contains(strtolower($item->title), 'community culture and wellbeing');
+
+                $scheduleItems = $scheduleItems->filter(function ($item) {
+                    return ! str_contains(strtolower($item->title), 'community culture and wellbeing');
                 });
-                
+
                 // Create wellness schedule item with proper Carbon datetime instances
                 $wellnessStartTime = Carbon::parse($userWellnessSession->start_time);
                 $wellnessEndTime = Carbon::parse($userWellnessSession->end_time);
-                
+
                 $wellnessScheduleItem = new ScheduleItem([
                     'title' => $userWellnessSession->title,
                     'description' => $userWellnessSession->description,
@@ -299,22 +314,22 @@ class ScheduleController extends Controller
                     'equipment_needed' => $userWellnessSession->equipment_needed,
                     'special_requirements' => $userWellnessSession->special_requirements,
                     'is_active' => true,
-                    'session_type' => 'wellness'
+                    'session_type' => 'wellness',
                 ]);
-                
+
                 // Add wellness session to the collection
                 $scheduleItems->push($wellnessScheduleItem);
-                
+
                 // Sort by start_time chronologically (ensuring proper Carbon comparison)
-                $scheduleItems = $scheduleItems->sortBy(function($item) {
+                $scheduleItems = $scheduleItems->sortBy(function ($item) {
                     return $item->start_time ? $item->start_time->timestamp : 0;
                 })->values();
             }
         }
-        
+
         return view('schedule.index', compact(
             'user',
-            'divisions', 
+            'divisions',
             'selectedDivisions',
             'allDivisionsSelected',
             'allSchoolSelected',
@@ -322,7 +337,11 @@ class ScheduleController extends Controller
             'userWellnessSession',
             'eventDates',
             'activeTab',
-            'selectedDate'
+            'selectedDate',
+            'activePDDay',
+            'activePDDayForSeason',
+            'archivedPDDays',
+            'isArchiveView'
         ))->with('season', $season);
     }
 
@@ -333,7 +352,7 @@ class ScheduleController extends Controller
     {
         $user = auth()->user();
         $academicYear = $request->get('year', PDDay::getCurrentAcademicYear());
-        
+
         // Get all PD days for the selected academic year
         $pdDays = PDDay::where('academic_year', $academicYear)
             ->orderBy('start_date')

--- a/app/Models/PDDay.php
+++ b/app/Models/PDDay.php
@@ -2,10 +2,10 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Carbon\Carbon;
 
 class PDDay extends Model
 {
@@ -19,6 +19,7 @@ class PDDay extends Model
         'start_date',
         'end_date',
         'is_active',
+        'archived_at',
         'season',
         'academic_year',
     ];
@@ -27,6 +28,7 @@ class PDDay extends Model
         'start_date' => 'date',
         'end_date' => 'date',
         'is_active' => 'boolean',
+        'archived_at' => 'datetime',
     ];
 
     /**
@@ -52,16 +54,16 @@ class PDDay extends Model
     {
         $start = Carbon::parse($this->start_date);
         $end = Carbon::parse($this->end_date);
-        
+
         if ($start->isSameDay($end)) {
             return $start->format('F j, Y');
         }
-        
+
         if ($start->month === $end->month) {
-            return $start->format('F j') . '-' . $end->format('j, Y');
+            return $start->format('F j').'-'.$end->format('j, Y');
         }
-        
-        return $start->format('F j') . ' - ' . $end->format('F j, Y');
+
+        return $start->format('F j').' - '.$end->format('F j, Y');
     }
 
     /**
@@ -131,9 +133,10 @@ class PDDay extends Model
 
         // Academic year runs Aug 1 - Jul 31
         if ($month >= 8) {
-            return $year . '-' . ($year + 1);
+            return $year.'-'.($year + 1);
         }
-        return ($year - 1) . '-' . $year;
+
+        return ($year - 1).'-'.$year;
     }
 
     /**
@@ -142,5 +145,76 @@ class PDDay extends Model
     public function isCurrentAcademicYear(): bool
     {
         return $this->academic_year === self::getCurrentAcademicYear();
+    }
+
+    /**
+     * Check if this PD day is archived
+     */
+    public function isArchived(): bool
+    {
+        return $this->archived_at !== null;
+    }
+
+    /**
+     * Scope to get only archived PD days
+     */
+    public function scopeArchived($query)
+    {
+        return $query->whereNotNull('archived_at');
+    }
+
+    /**
+     * Scope to get only non-archived PD days
+     */
+    public function scopeNotArchived($query)
+    {
+        return $query->whereNull('archived_at');
+    }
+
+    /**
+     * Archive this PD day
+     */
+    public function archive(): bool
+    {
+        if ($this->is_active) {
+            return false;
+        }
+
+        $this->archived_at = Carbon::now();
+
+        return $this->save();
+    }
+
+    /**
+     * Unarchive this PD day
+     */
+    public function unarchive(): bool
+    {
+        $this->archived_at = null;
+
+        return $this->save();
+    }
+
+    /**
+     * Get the status of this PD day (active, inactive, or archived)
+     */
+    public function getStatusAttribute(): string
+    {
+        if ($this->isArchived()) {
+            return 'archived';
+        }
+
+        return $this->is_active ? 'active' : 'inactive';
+    }
+
+    /**
+     * Get archived PD days for a specific season
+     */
+    public static function getArchivedBySeason(string $season)
+    {
+        return static::archived()
+            ->where('season', $season)
+            ->orderBy('start_date', 'desc')
+            ->get();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,12 +2,13 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Facades\View;
-use App\Models\PLWednesdaySetting;
-use App\Models\WellnessSetting;
+use App\Models\PDDay;
 use App\Models\PLDaysSetting;
+use App\Models\PLWednesdaySetting;
 use App\Models\TTTSetting;
+use App\Models\WellnessSetting;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -36,6 +37,8 @@ class AppServiceProvider extends ServiceProvider
                 'wellnessActive' => WellnessSetting::isActive(),
                 'plDaysActive' => PLDaysSetting::isActive(),
                 'tttActive' => TTTSetting::isActive(),
+                'archivedFallPDDays' => PDDay::getArchivedBySeason('fall'),
+                'archivedSpringPDDays' => PDDay::getArchivedBySeason('spring'),
             ]);
         });
     }

--- a/database/migrations/2026_01_17_140841_add_archived_at_to_p_d_days_table.php
+++ b/database/migrations/2026_01_17_140841_add_archived_at_to_p_d_days_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('p_d_days', function (Blueprint $table) {
+            $table->timestamp('archived_at')->nullable()->after('is_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('p_d_days', function (Blueprint $table) {
+            $table->dropColumn('archived_at');
+        });
+    }
+};

--- a/resources/views/admin/pddays/index.blade.php
+++ b/resources/views/admin/pddays/index.blade.php
@@ -10,7 +10,7 @@
             <h1 class="text-3xl font-bold text-gray-900">PL Days Management</h1>
             <p class="mt-2 text-gray-600">Configure professional learning day events</p>
         </div>
-        <a href="{{ route('admin.pddays.create') }}" class="inline-flex items-center px-6 py-3 bg-gray-900 border border-transparent rounded-md font-semibold text-white hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 shadow-lg whitespace-nowrap">
+        <a href="{{ route('admin.pddays.create') }}" class="inline-flex items-center px-6 py-3 border border-transparent rounded-md font-semibold text-white focus:outline-none focus:ring-2 focus:ring-offset-2 shadow-lg whitespace-nowrap transition-colors" style="background-color: var(--tlc-orange);" onmouseover="this.style.backgroundColor='#d97706'" onmouseout="this.style.backgroundColor='var(--tlc-orange)'" onfocus="this.style.outline='none'; this.style.boxShadow='0 0 0 2px var(--tlc-orange)'">
             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
             </svg>
@@ -63,10 +63,17 @@
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
                 @forelse($pdDays as $pdDay)
-                    <tr class="{{ $pdDay->is_active ? 'bg-green-50' : '' }}">
+                    <tr class="{{ $pdDay->isArchived() ? 'bg-purple-50' : ($pdDay->is_active ? 'bg-green-50' : '') }}">
                         <td class="px-6 py-4 whitespace-nowrap">
                             <div class="flex items-center">
-                                @if($pdDay->is_active)
+                                @if($pdDay->isArchived())
+                                    <span class="flex-shrink-0 mr-2">
+                                        <svg class="h-5 w-5 text-purple-500" fill="currentColor" viewBox="0 0 20 20">
+                                            <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
+                                            <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
+                                        </svg>
+                                    </span>
+                                @elseif($pdDay->is_active)
                                     <span class="flex-shrink-0 mr-2">
                                         <svg class="h-5 w-5 text-green-500" fill="currentColor" viewBox="0 0 20 20">
                                             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
@@ -85,7 +92,11 @@
                             {{ $pdDay->date_range }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            @if($pdDay->is_active)
+                            @if($pdDay->isArchived())
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
+                                    Archived
+                                </span>
+                            @elseif($pdDay->is_active)
                                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
                                     Active
                                 </span>
@@ -103,28 +114,52 @@
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                             <div class="flex items-center justify-end space-x-2">
-                                <!-- Toggle Active -->
-                                <form method="POST" action="{{ route('admin.pddays.toggle-active', $pdDay) }}" class="inline">
-                                    @csrf
-                                    <button type="submit" class="text-gray-600 hover:text-gray-900" title="{{ $pdDay->is_active ? 'Deactivate' : 'Activate' }}">
-                                        @if($pdDay->is_active)
+                                @if($pdDay->isArchived())
+                                    <!-- Unarchive -->
+                                    <form method="POST" action="{{ route('admin.pddays.unarchive', $pdDay) }}" class="inline">
+                                        @csrf
+                                        <button type="submit" class="text-purple-600 hover:text-purple-900" title="Unarchive">
                                             <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
                                             </svg>
-                                        @else
-                                            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                                            </svg>
-                                        @endif
-                                    </button>
-                                </form>
+                                        </button>
+                                    </form>
+                                @else
+                                    <!-- Toggle Active -->
+                                    <form method="POST" action="{{ route('admin.pddays.toggle-active', $pdDay) }}" class="inline">
+                                        @csrf
+                                        <button type="submit" class="text-gray-600 hover:text-gray-900" title="{{ $pdDay->is_active ? 'Deactivate' : 'Activate' }}">
+                                            @if($pdDay->is_active)
+                                                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+                                                </svg>
+                                            @else
+                                                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                                                </svg>
+                                            @endif
+                                        </button>
+                                    </form>
 
-                                <!-- Edit -->
-                                <a href="{{ route('admin.pddays.edit', $pdDay) }}" class="text-blue-600 hover:text-blue-900" title="Edit">
-                                    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-                                    </svg>
-                                </a>
+                                    <!-- Edit -->
+                                    <a href="{{ route('admin.pddays.edit', $pdDay) }}" class="text-blue-600 hover:text-blue-900" title="Edit">
+                                        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                                        </svg>
+                                    </a>
+
+                                    <!-- Archive (only for inactive) -->
+                                    @if(!$pdDay->is_active)
+                                        <form method="POST" action="{{ route('admin.pddays.archive', $pdDay) }}" class="inline">
+                                            @csrf
+                                            <button type="submit" class="text-purple-600 hover:text-purple-900" title="Archive">
+                                                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4l3 3m0 0l3-3m-3 3V9"/>
+                                                </svg>
+                                            </button>
+                                        </form>
+                                    @endif
+                                @endif
 
                                 <!-- Delete -->
                                 <form method="POST" action="{{ route('admin.pddays.destroy', $pdDay) }}" class="inline" onsubmit="return confirm('Are you sure you want to delete this PL Day? This action cannot be undone.');">
@@ -173,7 +208,24 @@
             </div>
             <div class="ml-3">
                 <p class="text-sm text-blue-700">
-                    <strong>Note:</strong> Only one PL Day can be active at a time. The active PL Day determines which events are displayed to users on the public-facing site. When you activate a PL Day, all other PL Days will be automatically deactivated.
+                    <strong>Note:</strong> Only one PL Day can be active per season (Fall/Spring). This allows you to have both an active Fall PL Day and an active Spring PL Day simultaneously. When you activate a PL Day, other PL Days of the same season will be automatically deactivated.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Archive Help Info -->
+    <div class="mt-4 bg-purple-50 border-l-4 border-purple-400 p-4">
+        <div class="flex">
+            <div class="flex-shrink-0">
+                <svg class="h-5 w-5 text-purple-400" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
+                    <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
+                </svg>
+            </div>
+            <div class="ml-3">
+                <p class="text-sm text-purple-700">
+                    <strong>Archive:</strong> Archived PL Days are read-only and appear as year tabs on the user-facing schedule pages. Users can browse archived content but cannot add sessions to My PL. To archive a PL Day, first deactivate it, then click the archive button.
                 </p>
             </div>
         </div>

--- a/resources/views/layouts/user.blade.php
+++ b/resources/views/layouts/user.blade.php
@@ -230,12 +230,19 @@
                             </svg>
                         </button>
                         <div class="mobile-submenu {{ request()->routeIs('fall.*') ? 'open' : '' }}">
-                            <a href="{{ route('fall.schedule') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('fall.schedule') ? 'text-tlc-gold font-semibold' : '' }}">
+                            <a href="{{ route('fall.schedule') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('fall.schedule') && !request()->route('pdday') ? 'text-tlc-gold font-semibold' : '' }}">
                                 Schedule
                             </a>
                             <a href="{{ route('fall.wellness') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('fall.wellness') ? 'text-tlc-gold font-semibold' : '' }}">
                                 Wellness
                             </a>
+                            @if(isset($archivedFallPDDays) && $archivedFallPDDays->count() > 0)
+                                @foreach($archivedFallPDDays as $archived)
+                                <a href="{{ route('fall.schedule', ['pdday' => $archived->id]) }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->route('pdday') && request()->route('pdday')->id == $archived->id ? 'text-tlc-gold font-semibold' : '' }}">
+                                    📁 {{ $archived->academic_year }}
+                                </a>
+                                @endforeach
+                            @endif
                         </div>
                     </div>
                     @endif
@@ -250,7 +257,7 @@
                             </svg>
                         </button>
                         <div class="mobile-submenu {{ request()->routeIs('spring.*') ? 'open' : '' }}">
-                            <a href="{{ route('spring.schedule') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.schedule') ? 'text-tlc-gold font-semibold' : '' }}">
+                            <a href="{{ route('spring.schedule') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.schedule') && !request()->route('pdday') ? 'text-tlc-gold font-semibold' : '' }}">
                                 Schedule
                             </a>
                             <a href="{{ route('spring.wellness') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.wellness') ? 'text-tlc-gold font-semibold' : '' }}">
@@ -260,6 +267,13 @@
                             <a href="{{ route('spring.ttt') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.ttt') ? 'text-tlc-gold font-semibold' : '' }}">
                                 TTT
                             </a>
+                            @endif
+                            @if(isset($archivedSpringPDDays) && $archivedSpringPDDays->count() > 0)
+                                @foreach($archivedSpringPDDays as $archived)
+                                <a href="{{ route('spring.schedule', ['pdday' => $archived->id]) }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->route('pdday') && request()->route('pdday')->id == $archived->id ? 'text-tlc-gold font-semibold' : '' }}">
+                                    📁 {{ $archived->academic_year }}
+                                </a>
+                                @endforeach
                             @endif
                         </div>
                     </div>
@@ -301,14 +315,27 @@
     <div class="sub-nav">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center space-x-2 py-2">
-                <a href="{{ route('fall.schedule') }}" 
-                   class="sub-nav-item {{ request()->routeIs('fall.schedule') ? 'active' : '' }}">
+                <a href="{{ route('fall.schedule') }}"
+                   class="sub-nav-item {{ request()->routeIs('fall.schedule') && !request()->route('pdday') ? 'active' : '' }}">
                     Schedule
                 </a>
-                <a href="{{ route('fall.wellness') }}" 
+                <a href="{{ route('fall.wellness') }}"
                    class="sub-nav-item {{ request()->routeIs('fall.wellness') ? 'active' : '' }}">
                     Wellness
                 </a>
+                @if(isset($archivedFallPDDays) && $archivedFallPDDays->count() > 0)
+                    @foreach($archivedFallPDDays as $archived)
+                    <a href="{{ route('fall.schedule', ['pdday' => $archived->id]) }}"
+                       class="sub-nav-item {{ request()->route('pdday') && request()->route('pdday')->id == $archived->id ? 'active' : '' }}">
+                        <span class="inline-flex items-center">
+                            <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+                            </svg>
+                            {{ $archived->academic_year }}
+                        </span>
+                    </a>
+                    @endforeach
+                @endif
             </div>
         </div>
     </div>
@@ -318,19 +345,32 @@
     <div class="sub-nav">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center space-x-2 py-2">
-                <a href="{{ route('spring.schedule') }}" 
-                   class="sub-nav-item {{ request()->routeIs('spring.schedule') ? 'active' : '' }}">
+                <a href="{{ route('spring.schedule') }}"
+                   class="sub-nav-item {{ request()->routeIs('spring.schedule') && !request()->route('pdday') ? 'active' : '' }}">
                     Schedule
                 </a>
-                <a href="{{ route('spring.wellness') }}" 
+                <a href="{{ route('spring.wellness') }}"
                    class="sub-nav-item {{ request()->routeIs('spring.wellness') ? 'active' : '' }}">
                     Wellness
                 </a>
                 @if($tttActive ?? false)
-                <a href="{{ route('spring.ttt') }}" 
+                <a href="{{ route('spring.ttt') }}"
                    class="sub-nav-item {{ request()->routeIs('spring.ttt') ? 'active' : '' }}">
                     TTT
                 </a>
+                @endif
+                @if(isset($archivedSpringPDDays) && $archivedSpringPDDays->count() > 0)
+                    @foreach($archivedSpringPDDays as $archived)
+                    <a href="{{ route('spring.schedule', ['pdday' => $archived->id]) }}"
+                       class="sub-nav-item {{ request()->route('pdday') && request()->route('pdday')->id == $archived->id ? 'active' : '' }}">
+                        <span class="inline-flex items-center">
+                            <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+                            </svg>
+                            {{ $archived->academic_year }}
+                        </span>
+                    </a>
+                    @endforeach
                 @endif
             </div>
         </div>

--- a/resources/views/schedule/index.blade.php
+++ b/resources/views/schedule/index.blade.php
@@ -628,6 +628,7 @@ body {
   cursor: pointer;
   accent-color: var(--tlc-orange);
   flex-shrink: 0;
+  background-color: white;
 }
 
 .my-pl-checkbox-text {
@@ -640,25 +641,158 @@ body {
 .my-pl-checkbox:checked + .my-pl-checkbox-text {
   color: var(--tlc-orange);
 }
+
+/* Archive Tabs Styling */
+.archive-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  justify-content: center;
+}
+
+.archive-tabs a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: none;
+  transition: all 0.3s ease;
+  background: #ffffff;
+  color: var(--tlc-navy);
+  border: 2px solid #e5e7eb;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.archive-tabs a:hover {
+  border-color: var(--tlc-gold);
+  box-shadow: 0 4px 12px rgba(244, 211, 94, 0.25);
+  transform: translateY(-2px);
+}
+
+.archive-tabs a.active {
+  background: linear-gradient(135deg, var(--tlc-navy), #164773);
+  color: #ffffff;
+  border-color: var(--tlc-navy);
+  box-shadow: 0 4px 12px rgba(13, 59, 102, 0.3);
+}
+
+.archive-tabs a.active:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(13, 59, 102, 0.4);
+}
+
+.archive-tabs .current-badge {
+  background: var(--tlc-gold);
+  color: var(--tlc-navy);
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.archive-tabs a.active .current-badge {
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+}
+
+/* Archive Banner */
+.archive-banner {
+  background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
+  color: #ffffff;
+  padding: 1rem 1.5rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(124, 58, 237, 0.25);
+}
+
+.archive-banner svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+@media (max-width: 640px) {
+  .archive-tabs {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .archive-tabs a {
+    justify-content: center;
+  }
+}
 </style>
 <div class="min-h-screen" style="background-color: var(--tlc-cream);">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <!-- Day Selector Cards -->
-        @if(count($eventDates) >= 2)
         @php
             // Determine which route to use based on current route
             $currentRoute = request()->route()->getName();
             if (str_contains($currentRoute, 'spring')) {
                 $scheduleRoute = 'spring.schedule';
+                $currentSeason = 'spring';
             } elseif (str_contains($currentRoute, 'fall')) {
                 $scheduleRoute = 'fall.schedule';
+                $currentSeason = 'fall';
             } else {
                 $scheduleRoute = 'dashboard';
+                $currentSeason = 'fall';
             }
+        @endphp
+
+        <!-- Year Tabs for Archives -->
+        @if(isset($archivedPDDays) && ($archivedPDDays->count() > 0 || (isset($isArchiveView) && $isArchiveView)))
+        <div class="archive-tabs">
+            {{-- Current/Active tab --}}
+            @if(isset($activePDDayForSeason) && $activePDDayForSeason)
+            <a href="{{ route($scheduleRoute) }}"
+               class="{{ !(isset($isArchiveView) && $isArchiveView) ? 'active' : '' }}">
+                {{ $activePDDayForSeason->academic_year ?? 'Current' }}
+                @if(!(isset($isArchiveView) && $isArchiveView))
+                    <span class="current-badge">Current</span>
+                @endif
+            </a>
+            @endif
+
+            {{-- Archived year tabs --}}
+            @foreach($archivedPDDays as $archived)
+            <a href="{{ route($scheduleRoute, ['pdday' => $archived->id]) }}"
+               class="{{ (isset($isArchiveView) && $isArchiveView && isset($activePDDay) && $activePDDay->id === $archived->id) ? 'active' : '' }}">
+                📁 {{ $archived->academic_year }}
+            </a>
+            @endforeach
+        </div>
+        @endif
+
+        <!-- Archive Banner -->
+        @if(isset($isArchiveView) && $isArchiveView && isset($activePDDay))
+        <div class="archive-banner">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+            </svg>
+            <span>Viewing archived content from {{ $activePDDay->academic_year }}</span>
+        </div>
+        @endif
+
+        <!-- Day Selector Cards -->
+        @if(count($eventDates) >= 2)
+        @php
+            // Build route params, preserving pdday for archive views
+            $dayRouteParams = (isset($isArchiveView) && $isArchiveView && isset($activePDDay))
+                ? ['pdday' => $activePDDay->id]
+                : [];
         @endphp
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
             <div class="day-card hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1 {{ $activeTab === 'day1' ? 'selected' : '' }}">
-                <a href="{{ route($scheduleRoute, ['day' => 'day1'] + request()->query()) }}" class="block">
+                <a href="{{ route($scheduleRoute, array_merge($dayRouteParams, ['day' => 'day1'])) }}" class="block">
                     <div class="text-center">
                         <div class="text-6xl mb-4">📅</div>
                         <h3 class="text-2xl font-bold mb-2">Day 1</h3>
@@ -670,7 +804,7 @@ body {
             </div>
 
             <div class="day-card hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1 {{ $activeTab === 'day2' ? 'selected' : '' }}">
-                <a href="{{ route($scheduleRoute, ['day' => 'day2'] + request()->query()) }}" class="block">
+                <a href="{{ route($scheduleRoute, array_merge($dayRouteParams, ['day' => 'day2'])) }}" class="block">
                     <div class="text-center">
                         <div class="text-6xl mb-4">📅</div>
                         <h3 class="text-2xl font-bold mb-2">Day 2</h3>
@@ -829,11 +963,11 @@ body {
                                             Add to Calendar
                                         </a>
                                         
-                                        <!-- Add to My PL Checkbox -->
-                                        @if($item->id)
+                                        <!-- Add to My PL Checkbox (hidden for archived content) -->
+                                        @if($item->id && !(isset($isArchiveView) && $isArchiveView))
                                         <label class="my-pl-checkbox-label" onclick="event.stopPropagation();">
-                                            <input type="checkbox" 
-                                                   class="my-pl-checkbox" 
+                                            <input type="checkbox"
+                                                   class="my-pl-checkbox"
                                                    {{ auth()->user()->hasSelected($item) ? 'checked' : '' }}
                                                    onchange="toggleMyPL('schedule_item', {{ $item->id }}, this)">
                                             <span class="my-pl-checkbox-text">Add to My PL</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,8 +46,8 @@ Route::middleware(['user.only'])->group(function () {
 
     // Fall PL Day Routes
     Route::prefix('fall-pl-day')->group(function () {
-        Route::get('/schedule', [ScheduleController::class, 'fallIndex'])->name('fall.schedule');
-        Route::get('/schedule/{scheduleItem}', [ScheduleController::class, 'show'])->name('fall.schedule.show');
+        Route::get('/schedule/{pdday?}', [ScheduleController::class, 'fallIndex'])->name('fall.schedule');
+        Route::get('/schedule-item/{scheduleItem}', [ScheduleController::class, 'show'])->name('fall.schedule.show');
         Route::get('/wellness', [WellnessController::class, 'fallIndex'])->name('fall.wellness');
         Route::get('/wellness/{session}', [WellnessController::class, 'show'])->name('fall.wellness.show');
         Route::post('/wellness/{session}/enroll', [WellnessController::class, 'enroll'])->name('fall.wellness.enroll');
@@ -55,8 +55,8 @@ Route::middleware(['user.only'])->group(function () {
 
     // Spring PL Days Routes
     Route::prefix('spring-pl-days')->group(function () {
-        Route::get('/schedule', [ScheduleController::class, 'springIndex'])->name('spring.schedule');
-        Route::get('/schedule/{scheduleItem}', [ScheduleController::class, 'show'])->name('spring.schedule.show');
+        Route::get('/schedule/{pdday?}', [ScheduleController::class, 'springIndex'])->name('spring.schedule');
+        Route::get('/schedule-item/{scheduleItem}', [ScheduleController::class, 'show'])->name('spring.schedule.show');
         Route::get('/wellness', [WellnessController::class, 'springIndex'])->name('spring.wellness');
         Route::get('/wellness/{session}', [WellnessController::class, 'show'])->name('spring.wellness.show');
         Route::post('/wellness/{session}/enroll', [WellnessController::class, 'enroll'])->name('spring.wellness.enroll');
@@ -116,6 +116,8 @@ Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(fun
     // PL Days Management
     Route::resource('pddays', PDDayController::class)->except(['show']);
     Route::post('/pddays/{pdday}/toggle-active', [PDDayController::class, 'toggleActive'])->name('pddays.toggle-active');
+    Route::post('/pddays/{pdday}/archive', [PDDayController::class, 'archive'])->name('pddays.archive');
+    Route::post('/pddays/{pdday}/unarchive', [PDDayController::class, 'unarchive'])->name('pddays.unarchive');
     
     // PL Wednesday Management
     Route::post('/pl-wednesday/toggle-active', [AdminPLWednesdayController::class, 'toggleActive'])->name('pl-wednesday.toggle-active');


### PR DESCRIPTION
## Summary
- Add archive functionality for PL Days - archived content is read-only and visible in navigation
- Archived PL Days appear in the sub-navigation bar (after TTT for Spring, after Wellness for Fall)
- Archive banner shown when viewing archived content
- "Add to My PL" checkbox hidden for archived schedules
- Purple status badges for archived items in admin panel
- Allow one active PL Day per season (Fall/Spring can both have active PL Days)

## Test plan
- [ ] Archive a PL Day from admin (must deactivate first)
- [ ] Verify archived PL Day appears in sub-navigation
- [ ] Click archived link, verify schedule loads with archive banner
- [ ] Verify "Add to My PL" checkbox is hidden on archived view
- [ ] Verify can switch between Day 1/Day 2 on archived view
- [ ] Unarchive and verify it returns to inactive state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds full archiving to PL Days with season-aware activation and user-facing navigation for past years.
> 
> - Introduces `archived_at` on `p_d_days` (migration) with model helpers (`isArchived`, `archive`, `unarchive`, scopes, `status`)
> - Admin: block edit/activate when archived; new `archive`/`unarchive` actions; season-scoped activation (deactivate same-season only); admin list shows archived badge/actions
> - Schedule: season views accept optional `pdday` to render archived schedules; adds year tabs and archive banner; hides "Add to My PL" for archives; wellness substitution disabled on archives
> - Navigation: shares `archivedFallPDDays`/`archivedSpringPDDays` via `AppServiceProvider`; surfaces archived year links in mobile/desktop sub-nav
> - Routes: fall/spring schedule accept optional `{pdday?}`; schedule item routes renamed to `/schedule-item/{scheduleItem}`; admin routes for archive/unarchive added
> - UI tweaks: day-tab links preserve `pdday`; styling for archive tabs/banner and admin button color
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 941becf4467d7e042ed311056e5fd35a7d2147f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->