### PR TITLE
Rename Teachers Teaching Teachers (TTT) to Collaborative Community Learning Sessions (CCL)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-TLC 2.0 is a Laravel 12.x web application for managing Professional Development activities at the American Embassy School (AES). It handles PD Days, Wellness Sessions, PL Wednesday sessions, and Teachers Teaching Teachers (TTT) programs.
+TLC 2.0 is a Laravel 12.x web application for managing Professional Development activities at the American Embassy School (AES). It handles PD Days, Wellness Sessions, PL Wednesday sessions, and Collaborative Community Learning Sessions (CCL) programs.
 
 ## Development Commands
 
@@ -41,13 +41,13 @@ Each major feature has a settings model that enables/disables it globally:
 - `PLDaysSetting` - Fall/Spring PD Days
 - `WellnessSetting` - Wellness Sessions
 - `PLWednesdaySetting` - PL Wednesday
-- `TTTSetting` - Teachers Teaching Teachers
+- `CCLSetting` - Collaborative Community Learning Sessions
 
 Check toggle state before rendering features: `PLWednesdaySetting::first()->is_active`
 
 ### Polymorphic "My PL" System
 `UserSelectedSession` uses polymorphic `selectable` relation to track user selections across all session types:
-- `selectable_type`: Model class (ScheduleItem, WellnessSession, PLWednesdaySession, TTTSession)
+- `selectable_type`: Model class (ScheduleItem, WellnessSession, PLWednesdaySession, CCLSession)
 - `selectable_id`: Session primary key
 
 ### Layout System
@@ -56,7 +56,7 @@ Check toggle state before rendering features: `PLWednesdaySetting::first()->is_a
 - Views organized by feature: `admin/[feature]/`, `schedule/`, `wellness/`, `pl-wednesday/`, `my-pl/`
 
 ### Key Model Relationships
-- `PDDay` has many `ScheduleItem`, `WellnessSession`, `TTTSession`
+- `PDDay` has many `ScheduleItem`, `WellnessSession`, `CCLSession`
 - `ScheduleItem` belongs to many `Division` via pivot table
 - `ScheduleItem` has many `ScheduleItemLink`
 - Sessions morph many `UserSelectedSession`

--- a/app/Http/Controllers/Admin/CCLController.php
+++ b/app/Http/Controllers/Admin/CCLController.php
@@ -3,45 +3,45 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use App\Models\TTTSession;
-use App\Models\TTTSetting;
-use App\Models\TTTLink;
+use App\Models\CCLSession;
+use App\Models\CCLSetting;
+use App\Models\CCLLink;
 use App\Models\PDDay;
 use App\Models\Division;
 use App\Models\ScheduleItem;
 use App\Models\UserSession;
 use Illuminate\Http\Request;
 
-class TTTController extends Controller
+class CCLController extends Controller
 {
     /**
-     * Display a listing of TTT sessions
+     * Display a listing of CCL sessions
      */
     public function index()
     {
-        $sessions = TTTSession::with(['division', 'pdDay'])
+        $sessions = CCLSession::with(['division', 'pdDay'])
             ->orderBy('date', 'desc')
             ->orderBy('start_time')
             ->paginate(15);
 
-        $settings = TTTSetting::getSettings();
+        $settings = CCLSetting::getSettings();
 
-        return view('admin.ttt.index', compact('sessions', 'settings'));
+        return view('admin.ccl.index', compact('sessions', 'settings'));
     }
 
     /**
-     * Show the form for creating a new TTT session
+     * Show the form for creating a new CCL session
      */
     public function create()
     {
         $divisions = Division::all();
         $pdDays = PDDay::orderBy('start_date', 'desc')->get();
 
-        return view('admin.ttt.create', compact('divisions', 'pdDays'));
+        return view('admin.ccl.create', compact('divisions', 'pdDays'));
     }
 
     /**
-     * Store a newly created TTT session
+     * Store a newly created CCL session
      */
     public function store(Request $request)
     {
@@ -68,7 +68,7 @@ class TTTController extends Controller
             'links.*.type' => 'nullable|string|max:50',
         ]);
 
-        $session = TTTSession::create([
+        $session = CCLSession::create([
             'title' => $validated['title'],
             'description' => $validated['description'] ?? null,
             'presenter_name' => $validated['presenter_name'],
@@ -99,23 +99,23 @@ class TTTController extends Controller
             }
         }
 
-        return redirect()->route('admin.ttt.index')
-            ->with('success', 'TTT Session created successfully.');
+        return redirect()->route('admin.ccl.index')
+            ->with('success', 'CCL Session created successfully.');
     }
 
     /**
-     * Display the specified TTT session
+     * Display the specified CCL session
      */
-    public function show(TTTSession $ttt)
+    public function show(CCLSession $ttt)
     {
         $ttt->load(['division', 'pdDay', 'links']);
 
-        // Find the corresponding ScheduleItem for this TTT session
+        // Find the corresponding ScheduleItem for this CCL session
         $scheduleItem = ScheduleItem::where('p_d_day_id', $ttt->p_d_day_id)
             ->where('date', $ttt->date)
             ->where('start_time', $ttt->start_time)
             ->where('title', $ttt->title)
-            ->where('session_type', 'ttt')
+            ->where('session_type', 'ccl')
             ->first();
 
         $confirmedParticipants = collect();
@@ -127,24 +127,24 @@ class TTTController extends Controller
                 ->get();
         }
 
-        return view('admin.ttt.show', compact('ttt', 'confirmedParticipants', 'scheduleItem'));
+        return view('admin.ccl.show', compact('ttt', 'confirmedParticipants', 'scheduleItem'));
     }
 
     /**
-     * Show the form for editing the specified TTT session
+     * Show the form for editing the specified CCL session
      */
-    public function edit(TTTSession $ttt)
+    public function edit(CCLSession $ttt)
     {
         $divisions = Division::all();
         $pdDays = PDDay::orderBy('start_date', 'desc')->get();
         $ttt->load('links');
 
-        // Find the corresponding ScheduleItem for this TTT session
+        // Find the corresponding ScheduleItem for this CCL session
         $scheduleItem = ScheduleItem::where('p_d_day_id', $ttt->p_d_day_id)
             ->where('date', $ttt->date)
             ->where('start_time', $ttt->start_time)
             ->where('title', $ttt->title)
-            ->where('session_type', 'ttt')
+            ->where('session_type', 'ccl')
             ->first();
 
         $confirmedParticipants = collect();
@@ -156,13 +156,13 @@ class TTTController extends Controller
                 ->get();
         }
 
-        return view('admin.ttt.edit', compact('ttt', 'divisions', 'pdDays', 'confirmedParticipants', 'scheduleItem'));
+        return view('admin.ccl.edit', compact('ttt', 'divisions', 'pdDays', 'confirmedParticipants', 'scheduleItem'));
     }
 
     /**
-     * Update the specified TTT session
+     * Update the specified CCL session
      */
-    public function update(Request $request, TTTSession $ttt)
+    public function update(Request $request, CCLSession $ttt)
     {
         $validated = $request->validate([
             'title' => 'required|string|max:255',
@@ -219,39 +219,39 @@ class TTTController extends Controller
             }
         }
 
-        return redirect()->route('admin.ttt.index')
-            ->with('success', 'TTT Session updated successfully.');
+        return redirect()->route('admin.ccl.index')
+            ->with('success', 'CCL Session updated successfully.');
     }
 
     /**
-     * Remove the specified TTT session
+     * Remove the specified CCL session
      */
-    public function destroy(TTTSession $ttt)
+    public function destroy(CCLSession $ttt)
     {
         $ttt->delete();
 
-        return redirect()->route('admin.ttt.index')
-            ->with('success', 'TTT Session deleted successfully.');
+        return redirect()->route('admin.ccl.index')
+            ->with('success', 'CCL Session deleted successfully.');
     }
 
     /**
-     * Toggle TTT feature active status
+     * Toggle CCL feature active status
      */
     public function toggleActive()
     {
-        $isActive = TTTSetting::toggle();
+        $isActive = CCLSetting::toggle();
 
         return response()->json([
             'success' => true,
             'is_active' => $isActive,
-            'message' => $isActive ? 'TTT feature enabled' : 'TTT feature disabled',
+            'message' => $isActive ? 'CCL feature enabled' : 'CCL feature disabled',
         ]);
     }
 
     /**
      * Toggle session status
      */
-    public function toggleSessionStatus(TTTSession $ttt)
+    public function toggleSessionStatus(CCLSession $ttt)
     {
         $ttt->is_active = !$ttt->is_active;
         $ttt->save();
@@ -261,9 +261,9 @@ class TTTController extends Controller
     }
 
     /**
-     * Remove user enrollment from TTT session
+     * Remove user enrollment from CCL session
      */
-    public function removeEnrollment(Request $request, TTTSession $ttt)
+    public function removeEnrollment(Request $request, CCLSession $ttt)
     {
         $request->validate([
             'user_id' => 'required|exists:users,id'
@@ -271,12 +271,12 @@ class TTTController extends Controller
 
         $user = \App\Models\User::findOrFail($request->user_id);
         
-        // Find the corresponding ScheduleItem for this TTT session
+        // Find the corresponding ScheduleItem for this CCL session
         $scheduleItem = ScheduleItem::where('p_d_day_id', $ttt->p_d_day_id)
             ->where('date', $ttt->date)
             ->where('start_time', $ttt->start_time)
             ->where('title', $ttt->title)
-            ->where('session_type', 'ttt')
+            ->where('session_type', 'ccl')
             ->first();
 
         if (!$scheduleItem) {

--- a/app/Http/Controllers/CCLController.php
+++ b/app/Http/Controllers/CCLController.php
@@ -2,28 +2,28 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\TTTSession;
-use App\Models\TTTSetting;
+use App\Models\CCLSession;
+use App\Models\CCLSetting;
 use App\Models\PDDay;
 use Illuminate\Http\Request;
 
-class TTTController extends Controller
+class CCLController extends Controller
 {
     /**
-     * Display TTT sessions for users
+     * Display CCL sessions for users
      */
     public function index(Request $request)
     {
-        // Check if TTT feature is active
-        if (!TTTSetting::isActive()) {
+        // Check if CCL feature is active
+        if (!CCLSetting::isActive()) {
             return redirect()->route('dashboard')
-                ->with('error', 'Teachers Teaching Teachers is not currently available.');
+                ->with('error', 'Collaborative Community Learning Sessions is not currently available.');
         }
 
         // Get active spring PD day
         $pdDay = PDDay::spring()->active()->first();
 
-        $sessions = TTTSession::active()
+        $sessions = CCLSession::active()
             ->when($pdDay, function($query) use ($pdDay) {
                 return $query->where('p_d_day_id', $pdDay->id);
             })
@@ -32,15 +32,15 @@ class TTTController extends Controller
             ->orderBy('start_time')
             ->get();
 
-        $settings = TTTSetting::getSettings();
+        $settings = CCLSetting::getSettings();
         
         // Check user enrollments for each session
         $user = auth()->user();
         $userEnrollments = [];
         if ($user && $pdDay) {
-            // Get all schedule items for TTT sessions
+            // Get all schedule items for CCL sessions
             $scheduleItems = \App\Models\ScheduleItem::where('p_d_day_id', $pdDay->id)
-                ->where('session_type', 'ttt')
+                ->where('session_type', 'ccl')
                 ->get()
                 ->keyBy(function($item) {
                     return $item->date->format('Y-m-d') . '_' . $item->start_time->format('H:i:s') . '_' . $item->title;
@@ -66,16 +66,16 @@ class TTTController extends Controller
             }
         }
 
-        return view('ttt.index', compact('sessions', 'settings', 'pdDay', 'userEnrollments'));
+        return view('ccl.index', compact('sessions', 'settings', 'pdDay', 'userEnrollments'));
     }
 
     /**
-     * Display a specific TTT session
+     * Display a specific CCL session
      */
-    public function show(TTTSession $session)
+    public function show(CCLSession $session)
     {
-        if (!TTTSetting::isActive() || !$session->is_active) {
-            return redirect()->route('spring.ttt')
+        if (!CCLSetting::isActive() || !$session->is_active) {
+            return redirect()->route('spring.ccl')
                 ->with('error', 'This session is not currently available.');
         }
 
@@ -85,12 +85,12 @@ class TTTController extends Controller
         $user = auth()->user();
         $userEnrollment = null;
         if ($user) {
-            // Find the corresponding ScheduleItem for this TTT session
+            // Find the corresponding ScheduleItem for this CCL session
             $scheduleItem = \App\Models\ScheduleItem::where('p_d_day_id', $session->p_d_day_id)
                 ->where('date', $session->date)
                 ->where('start_time', $session->start_time)
                 ->where('title', $session->title)
-                ->where('session_type', 'ttt')
+                ->where('session_type', 'ccl')
                 ->first();
             
             if ($scheduleItem) {
@@ -101,27 +101,27 @@ class TTTController extends Controller
             }
         }
 
-        return view('ttt.show', compact('session', 'userEnrollment'));
+        return view('ccl.show', compact('session', 'userEnrollment'));
     }
 
     /**
-     * Join a TTT session (enroll user)
+     * Join a CCL session (enroll user)
      */
-    public function join(Request $request, TTTSession $session)
+    public function join(Request $request, CCLSession $session)
     {
-        // Check if TTT feature is active
-        if (!TTTSetting::isActive() || !$session->is_active) {
+        // Check if CCL feature is active
+        if (!CCLSetting::isActive() || !$session->is_active) {
             return back()->with('error', 'This session is not currently available.');
         }
 
         $user = auth()->user();
         
-        // Find the corresponding ScheduleItem for this TTT session
+        // Find the corresponding ScheduleItem for this CCL session
         $scheduleItem = \App\Models\ScheduleItem::where('p_d_day_id', $session->p_d_day_id)
             ->where('date', $session->date)
             ->where('start_time', $session->start_time)
             ->where('title', $session->title)
-            ->where('session_type', 'ttt')
+            ->where('session_type', 'ccl')
             ->first();
         
         if (!$scheduleItem) {
@@ -138,16 +138,16 @@ class TTTController extends Controller
             return back()->with('error', 'You are already enrolled in this session.');
         }
         
-        // Check if user is already enrolled in any TTT session
-        $existingTTTEnrollment = \App\Models\UserSession::where('user_id', $user->id)
+        // Check if user is already enrolled in any CCL session
+        $existingCCLEnrollment = \App\Models\UserSession::where('user_id', $user->id)
             ->whereHas('scheduleItem', function($query) {
-                $query->where('session_type', 'ttt');
+                $query->where('session_type', 'ccl');
             })
             ->where('status', '!=', 'cancelled')
             ->first();
         
-        if ($existingTTTEnrollment) {
-            return back()->with('error', 'You can only join one TTT session. You are already enrolled in another TTT session.');
+        if ($existingCCLEnrollment) {
+            return back()->with('error', 'You can only join one CCL session. You are already enrolled in another CCL session.');
         }
         
         // Check for time conflicts with wellness session
@@ -166,7 +166,7 @@ class TTTController extends Controller
             $wellnessEnd = $wellnessSession->end_time;
             
             if ($tttStart < $wellnessEnd && $tttEnd > $wellnessStart) {
-                return back()->with('error', 'This TTT session conflicts with your selected wellness session time. Please select a TTT session at a different time.');
+                return back()->with('error', 'This CCL session conflicts with your selected wellness session time. Please select a CCL session at a different time.');
             }
         }
         

--- a/app/Http/Controllers/MyPLController.php
+++ b/app/Http/Controllers/MyPLController.php
@@ -7,7 +7,7 @@ use App\Models\UserSelectedSession;
 use App\Models\ScheduleItem;
 use App\Models\WellnessSession;
 use App\Models\PLWednesdaySession;
-use App\Models\TTTSession;
+use App\Models\CCLSession;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -32,7 +32,7 @@ class MyPLController extends Controller
             'schedule' => [],
             'wellness' => [],
             'pl_wednesday' => [],
-            'ttt' => [],
+            'ccl' => [],
         ];
 
         foreach ($selectedSessions as $selection) {
@@ -43,7 +43,7 @@ class MyPLController extends Controller
                 ScheduleItem::class => 'schedule',
                 WellnessSession::class => 'wellness',
                 PLWednesdaySession::class => 'pl_wednesday',
-                TTTSession::class => 'ttt',
+                CCLSession::class => 'ccl',
                 default => null,
             };
             
@@ -101,7 +101,7 @@ class MyPLController extends Controller
             'schedule_item' => ScheduleItem::class,
             'wellness_session' => WellnessSession::class,
             'pl_wednesday_session' => PLWednesdaySession::class,
-            'ttt_session' => TTTSession::class,
+            'ccl_session' => CCLSession::class,
         ];
 
         $class = $classMap[$type] ?? null;
@@ -185,7 +185,7 @@ class MyPLController extends Controller
                 $item['presenter'] = '';
                 // Calculate from duration
                 $item['contact_hours'] = round(($session->duration ?? 60) / 60, 2);
-            } elseif ($session instanceof TTTSession) {
+            } elseif ($session instanceof CCLSession) {
                 $item['date'] = $session->date;
                 $item['title'] = $session->title;
                 $item['presenter'] = $session->presenter_name ?? '';

--- a/app/Models/CCLLink.php
+++ b/app/Models/CCLLink.php
@@ -6,14 +6,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class TTTLink extends Model
+class CCLLink extends Model
 {
     use HasFactory;
 
-    protected $table = 'ttt_links';
+    protected $table = 'ccl_links';
 
     protected $fillable = [
-        'ttt_session_id',
+        'ccl_session_id',
         'title',
         'url',
         'type',
@@ -25,7 +25,7 @@ class TTTLink extends Model
      */
     public function session(): BelongsTo
     {
-        return $this->belongsTo(TTTSession::class, 'ttt_session_id');
+        return $this->belongsTo(CCLSession::class, 'ccl_session_id');
     }
 
     /**

--- a/app/Models/CCLSession.php
+++ b/app/Models/CCLSession.php
@@ -9,11 +9,11 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Carbon\Carbon;
 
-class TTTSession extends Model
+class CCLSession extends Model
 {
     use HasFactory;
 
-    protected $table = 'ttt_sessions';
+    protected $table = 'ccl_sessions';
 
     protected $fillable = [
         'title',
@@ -64,7 +64,7 @@ class TTTSession extends Model
      */
     public function links(): HasMany
     {
-        return $this->hasMany(TTTLink::class, 'ttt_session_id')->orderBy('order');
+        return $this->hasMany(CCLLink::class, 'ccl_session_id')->orderBy('order');
     }
 
     /**

--- a/app/Models/CCLSetting.php
+++ b/app/Models/CCLSetting.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class TTTSetting extends Model
+class CCLSetting extends Model
 {
     use HasFactory;
 
@@ -20,19 +20,19 @@ class TTTSetting extends Model
     ];
 
     /**
-     * Get the current TTT settings (singleton pattern)
+     * Get the current CCL settings (singleton pattern)
      */
     public static function getSettings(): self
     {
         return static::first() ?? static::create([
             'is_active' => false,
-            'title' => 'Teachers Teaching Teachers',
+            'title' => 'Collaborative Community Learning Sessions',
             'description' => 'Professional learning sessions led by our own teachers sharing their expertise.',
         ]);
     }
 
     /**
-     * Check if TTT feature is active
+     * Check if CCL feature is active
      */
     public static function isActive(): bool
     {
@@ -40,7 +40,7 @@ class TTTSetting extends Model
     }
 
     /**
-     * Toggle the TTT feature
+     * Toggle the CCL feature
      */
     public static function toggle(): bool
     {

--- a/app/Models/PDDay.php
+++ b/app/Models/PDDay.php
@@ -115,11 +115,11 @@ class PDDay extends Model
     }
 
     /**
-     * Get TTT sessions for this PD day
+     * Get CCL sessions for this PD day
      */
-    public function tttSessions(): HasMany
+    public function cclSessions(): HasMany
     {
-        return $this->hasMany(TTTSession::class, 'p_d_day_id');
+        return $this->hasMany(CCLSession::class, 'p_d_day_id');
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,7 +5,7 @@ namespace App\Providers;
 use App\Models\PDDay;
 use App\Models\PLDaysSetting;
 use App\Models\PLWednesdaySetting;
-use App\Models\TTTSetting;
+use App\Models\CCLSetting;
 use App\Models\WellnessSetting;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -36,7 +36,7 @@ class AppServiceProvider extends ServiceProvider
                 'plWednesdayActive' => PLWednesdaySetting::isActive(),
                 'wellnessActive' => WellnessSetting::isActive(),
                 'plDaysActive' => PLDaysSetting::isActive(),
-                'tttActive' => TTTSetting::isActive(),
+                'cclActive' => CCLSetting::isActive(),
                 'archivedFallPDDays' => PDDay::getArchivedBySeason('fall'),
                 'archivedSpringPDDays' => PDDay::getArchivedBySeason('spring'),
             ]);

--- a/database/migrations/2026_01_13_100002_create_ccl_settings_table.php
+++ b/database/migrations/2026_01_13_100002_create_ccl_settings_table.php
@@ -11,18 +11,18 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('ttt_settings', function (Blueprint $table) {
+        Schema::create('ccl_settings', function (Blueprint $table) {
             $table->id();
             $table->boolean('is_active')->default(false);
-            $table->string('title')->default('Teachers Teaching Teachers');
+            $table->string('title')->default('Collaborative Community Learning Sessions');
             $table->text('description')->nullable();
             $table->timestamps();
         });
 
         // Insert default settings
-        DB::table('ttt_settings')->insert([
+        DB::table('ccl_settings')->insert([
             'is_active' => false,
-            'title' => 'Teachers Teaching Teachers',
+            'title' => 'Collaborative Community Learning Sessions',
             'description' => 'Professional learning sessions led by our own teachers sharing their expertise.',
             'created_at' => now(),
             'updated_at' => now(),
@@ -34,6 +34,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('ttt_settings');
+        Schema::dropIfExists('ccl_settings');
     }
 };

--- a/database/migrations/2026_01_13_100003_create_ccl_sessions_table.php
+++ b/database/migrations/2026_01_13_100003_create_ccl_sessions_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('ttt_sessions', function (Blueprint $table) {
+        Schema::create('ccl_sessions', function (Blueprint $table) {
             $table->id();
             $table->string('title');
             $table->text('description')->nullable();
@@ -38,6 +38,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('ttt_sessions');
+        Schema::dropIfExists('ccl_sessions');
     }
 };

--- a/database/migrations/2026_01_13_100004_create_ccl_links_table.php
+++ b/database/migrations/2026_01_13_100004_create_ccl_links_table.php
@@ -11,9 +11,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('ttt_links', function (Blueprint $table) {
+        Schema::create('ccl_links', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('ttt_session_id')->constrained('ttt_sessions')->onDelete('cascade');
+            $table->foreignId('ccl_session_id')->constrained('ccl_sessions')->onDelete('cascade');
             $table->string('title');
             $table->string('url');
             $table->string('type')->default('resource'); // resource, video, document, etc.
@@ -27,6 +27,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('ttt_links');
+        Schema::dropIfExists('ccl_links');
     }
 };

--- a/database/seeders/CCLSessionSeeder.php
+++ b/database/seeders/CCLSessionSeeder.php
@@ -3,22 +3,22 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use App\Models\TTTSession;
-use App\Models\TTTSetting;
+use App\Models\CCLSession;
+use App\Models\CCLSetting;
 use App\Models\PDDay;
 use App\Models\Division;
 use App\Models\ScheduleItem;
 use Carbon\Carbon;
 
-class TTTSessionSeeder extends Seeder
+class CCLSessionSeeder extends Seeder
 {
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        // Ensure TTT is active
-        $settings = TTTSetting::getSettings();
+        // Ensure CCL is active
+        $settings = CCLSetting::getSettings();
         $settings->is_active = true;
         $settings->save();
 
@@ -29,7 +29,7 @@ class TTTSessionSeeder extends Seeder
             // Create a spring PD day if it doesn't exist
             $springPDDay = PDDay::create([
                 'title' => 'Spring 2026 Professional Learning Days',
-                'description' => 'Spring professional development sessions including TTT.',
+                'description' => 'Spring professional development sessions including CCL.',
                 'start_date' => Carbon::parse('2026-03-02'),
                 'end_date' => Carbon::parse('2026-03-03'),
                 'is_active' => true,
@@ -44,11 +44,11 @@ class TTTSessionSeeder extends Seeder
         $msDivision = Division::where('name', 'MS')->first();
         $hsDivision = Division::where('name', 'HS')->first();
 
-        // Create TTT sessions for the two time slots
-        // TTT Session 1: March 2nd, 1:30 PM - 2:30 PM
-        // TTT Session 2: March 3rd, 1:45 PM - 2:45 PM
+        // Create CCL sessions for the two time slots
+        // CCL Session 1: March 2nd, 1:30 PM - 2:30 PM
+        // CCL Session 2: March 3rd, 1:45 PM - 2:45 PM
         $sessions = [
-            // ===== TTT Session 1: March 2nd, 1:30 PM - 2:30 PM =====
+            // ===== CCL Session 1: March 2nd, 1:30 PM - 2:30 PM =====
             [
                 'title' => 'Innovative Assessment Strategies',
                 'description' => 'Learn creative ways to assess student learning beyond traditional tests. Explore project-based assessments, portfolios, and authentic evaluation methods that engage students and provide meaningful feedback.',
@@ -99,7 +99,7 @@ class TTTSessionSeeder extends Seeder
                 'is_active' => true,
             ],
 
-            // ===== TTT Session 2: March 3rd (Tuesday), 1:45 PM - 2:45 PM =====
+            // ===== CCL Session 2: March 3rd (Tuesday), 1:45 PM - 2:45 PM =====
             [
                 'title' => 'Project-Based Learning Essentials',
                 'description' => 'Learn how to design and implement engaging project-based learning experiences that connect curriculum to real-world applications. Includes examples from various subject areas.',
@@ -155,11 +155,11 @@ class TTTSessionSeeder extends Seeder
             $endTime = $sessionData['end_time'];
             $divisionId = $sessionData['division_id'];
             
-            // Convert start_time and end_time to time format (H:i:s) for TTTSession
+            // Convert start_time and end_time to time format (H:i:s) for CCLSession
             $sessionData['start_time'] = $startTime->format('H:i:s');
             $sessionData['end_time'] = $endTime->format('H:i:s');
             
-            $tttSession = TTTSession::create($sessionData);
+            $tttSession = CCLSession::create($sessionData);
             
             // Create corresponding ScheduleItem with capacity
             // Varying capacities for testing: 15, 20, or 25
@@ -180,7 +180,7 @@ class TTTSessionSeeder extends Seeder
                 'start_time' => $date->format('Y-m-d') . ' ' . $startTime->format('H:i:s'),
                 'end_time' => $date->format('Y-m-d') . ' ' . $endTime->format('H:i:s'),
                 'location' => $sessionData['location'],
-                'session_type' => 'ttt',
+                'session_type' => 'ccl',
                 'max_participants' => $maxParticipants,
                 'current_enrollment' => $currentEnrollment,
                 'is_active' => true,
@@ -195,6 +195,6 @@ class TTTSessionSeeder extends Seeder
             }
         }
 
-        $this->command->info('Created ' . count($sessions) . ' TTT sessions with schedule items.');
+        $this->command->info('Created ' . count($sessions) . ' CCL sessions with schedule items.');
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,7 +17,7 @@ class DatabaseSeeder extends Seeder
             DivisionSeeder::class,
             AdminUserSeeder::class,
             PDDaySeeder::class,
-            TTTSessionSeeder::class,
+            CCLSessionSeeder::class,
             WellnessSessionSeeder::class,
             ScheduleItemSeeder::class,
             ReportsTestDataSeeder::class,

--- a/database/seeders/ScheduleItemSeeder.php
+++ b/database/seeders/ScheduleItemSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\ScheduleItem;
-use App\Models\TTTSession;
+use App\Models\CCLSession;
 use App\Models\PDDay;
 use App\Models\Division;
 use Carbon\Carbon;
@@ -20,24 +20,24 @@ class ScheduleItemSeeder extends Seeder
         $springPDDay = PDDay::spring()->active()->first();
         
         if (!$springPDDay) {
-            $this->command->warn('No active Spring PD Day found. Please run PDDaySeeder or TTTSessionSeeder first.');
+            $this->command->warn('No active Spring PD Day found. Please run PDDaySeeder or CCLSessionSeeder first.');
             return;
         }
 
-        // Get all TTT sessions for this PD day
-        $tttSessions = TTTSession::where('p_d_day_id', $springPDDay->id)
+        // Get all CCL sessions for this PD day
+        $tttSessions = CCLSession::where('p_d_day_id', $springPDDay->id)
             ->where('is_active', true)
             ->get();
 
         if ($tttSessions->isEmpty()) {
-            $this->command->warn('No TTT sessions found for Spring PD Day. Please run TTTSessionSeeder first.');
+            $this->command->warn('No CCL sessions found for Spring PD Day. Please run CCLSessionSeeder first.');
             return;
         }
 
         $createdCount = 0;
 
         foreach ($tttSessions as $tttSession) {
-            // Check if schedule item already exists for this TTT session
+            // Check if schedule item already exists for this CCL session
             $existingItem = ScheduleItem::where('p_d_day_id', $springPDDay->id)
                 ->where('date', $tttSession->date)
                 ->where('start_time', $tttSession->start_time)
@@ -49,7 +49,7 @@ class ScheduleItemSeeder extends Seeder
                 continue;
             }
 
-            // Create schedule item from TTT session
+            // Create schedule item from CCL session
             $scheduleItem = ScheduleItem::create([
                 'title' => $tttSession->title,
                 'description' => $tttSession->description,
@@ -65,7 +65,7 @@ class ScheduleItemSeeder extends Seeder
                 'p_d_day_id' => $springPDDay->id,
             ]);
 
-            // Attach division if TTT session has one
+            // Attach division if CCL session has one
             if ($tttSession->division_id) {
                 $scheduleItem->divisions()->attach($tttSession->division_id);
             } else {
@@ -78,6 +78,6 @@ class ScheduleItemSeeder extends Seeder
             $this->command->info("Created schedule item: {$scheduleItem->title} - {$scheduleItem->start_time->format('M d, Y g:i A')}");
         }
 
-        $this->command->info("Successfully created {$createdCount} schedule items from TTT sessions.");
+        $this->command->info("Successfully created {$createdCount} schedule items from CCL sessions.");
     }
 }

--- a/database/seeders/WellnessSessionSeeder.php
+++ b/database/seeders/WellnessSessionSeeder.php
@@ -28,7 +28,7 @@ class WellnessSessionSeeder extends Seeder
             // Create a spring PD day if it doesn't exist
             $springPDDay = PDDay::create([
                 'title' => 'Spring 2026 Professional Learning Days',
-                'description' => 'Spring professional development sessions including Wellness and TTT.',
+                'description' => 'Spring professional development sessions including Wellness and CCL.',
                 'start_date' => Carbon::parse('2026-03-02'),
                 'end_date' => Carbon::parse('2026-03-03'),
                 'is_active' => true,

--- a/resources/views/admin/ccl/create.blade.php
+++ b/resources/views/admin/ccl/create.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Create TTT Session')
+@section('title', 'Create CCL Session')
 
 @section('content')
 <div class="min-h-screen bg-content py-8">
@@ -8,18 +8,18 @@
         <!-- Header -->
         <div class="mb-8">
             <div class="flex items-center mb-4">
-                <a href="{{ route('admin.ttt.index') }}" 
+                <a href="{{ route('admin.ccl.index') }}" 
                    class="mr-4 font-medium hover:opacity-70" style="color: var(--tlc-navy);">
-                    <i class="fas fa-arrow-left mr-2"></i>Back to TTT Sessions
+                    <i class="fas fa-arrow-left mr-2"></i>Back to CCL Sessions
                 </a>
             </div>
-            <h1 class="text-3xl font-bold text-gray-900">Create New TTT Session</h1>
-            <p class="text-gray-600 mt-1">Add a new Teachers Teaching Teachers session</p>
+            <h1 class="text-3xl font-bold text-gray-900">Create New CCL Session</h1>
+            <p class="text-gray-600 mt-1">Add a new Collaborative Community Learning Sessions session</p>
         </div>
 
         <!-- Form -->
         <div class="bg-white rounded-lg shadow-card border">
-            <form action="{{ route('admin.ttt.store') }}" method="POST" class="p-8 space-y-8">
+            <form action="{{ route('admin.ccl.store') }}" method="POST" class="p-8 space-y-8">
                 @csrf
 
                 <!-- Basic Information -->
@@ -221,7 +221,7 @@
 
                 <!-- Submit Buttons -->
                 <div class="border-t pt-6 flex justify-end space-x-4">
-                    <a href="{{ route('admin.ttt.index') }}" 
+                    <a href="{{ route('admin.ccl.index') }}" 
                        class="px-6 py-3 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors font-medium">
                         Cancel
                     </a>

--- a/resources/views/admin/ccl/edit.blade.php
+++ b/resources/views/admin/ccl/edit.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Edit TTT Session')
+@section('title', 'Edit CCL Session')
 
 @section('content')
 <div class="min-h-screen bg-content py-8">
@@ -8,13 +8,13 @@
         <!-- Header -->
         <div class="mb-8">
             <div class="flex items-center mb-4">
-                <a href="{{ route('admin.ttt.index') }}" 
+                <a href="{{ route('admin.ccl.index') }}" 
                    class="mr-4 font-medium hover:opacity-70" style="color: var(--tlc-navy);">
-                    <i class="fas fa-arrow-left mr-2"></i>Back to TTT Sessions
+                    <i class="fas fa-arrow-left mr-2"></i>Back to CCL Sessions
                 </a>
             </div>
-            <h1 class="text-3xl font-bold text-gray-900">Edit TTT Session</h1>
-            <p class="text-gray-600 mt-1">Update the TTT session details</p>
+            <h1 class="text-3xl font-bold text-gray-900">Edit CCL Session</h1>
+            <p class="text-gray-600 mt-1">Update the CCL session details</p>
         </div>
 
         <!-- Success/Error Messages -->
@@ -38,7 +38,7 @@
 
         <!-- Form -->
         <div class="bg-white rounded-lg shadow-card border">
-            <form action="{{ route('admin.ttt.update', $ttt) }}" method="POST" class="p-8 space-y-8">
+            <form action="{{ route('admin.ccl.update', $ccl) }}" method="POST" class="p-8 space-y-8">
                 @csrf
                 @method('PUT')
 
@@ -48,7 +48,7 @@
                         <label for="title" class="block text-sm font-medium text-gray-700 mb-1">
                             Session Title <span class="text-red-500">*</span>
                         </label>
-                        <input type="text" id="title" name="title" value="{{ old('title', $ttt->title) }}" required
+                        <input type="text" id="title" name="title" value="{{ old('title', $ccl->title) }}" required
                                class="w-full border border-gray-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-aes-blue focus:border-transparent
                                       @error('title') border-red-300 ring-2 ring-red-200 @enderror">
                         @error('title')
@@ -60,7 +60,7 @@
                         <label for="description" class="block text-sm font-medium text-gray-700 mb-1">Description</label>
                         <textarea id="description" name="description" rows="4"
                                   class="w-full border border-gray-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-aes-blue focus:border-transparent
-                                         @error('description') border-red-300 ring-2 ring-red-200 @enderror">{{ old('description', $ttt->description) }}</textarea>
+                                         @error('description') border-red-300 ring-2 ring-red-200 @enderror">{{ old('description', $ccl->description) }}</textarea>
                         @error('description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -68,7 +68,7 @@
 
                     <div>
                         <label for="location" class="block text-sm font-medium text-gray-700 mb-1">Location</label>
-                        <input type="text" id="location" name="location" value="{{ old('location', $ttt->location) }}"
+                        <input type="text" id="location" name="location" value="{{ old('location', $ccl->location) }}"
                                placeholder="e.g., Room 101, Library"
                                class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                       @error('location') border-red-300 @enderror">
@@ -84,7 +84,7 @@
                     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                         <div>
                             <label for="presenter_name" class="block text-sm font-medium text-gray-700 mb-1">Presenter Name <span class="text-red-500">*</span></label>
-                            <input type="text" id="presenter_name" name="presenter_name" value="{{ old('presenter_name', $ttt->presenter_name) }}" required
+                            <input type="text" id="presenter_name" name="presenter_name" value="{{ old('presenter_name', $ccl->presenter_name) }}" required
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('presenter_name') border-red-300 @enderror">
                             @error('presenter_name')
@@ -94,7 +94,7 @@
 
                         <div>
                             <label for="presenter_email" class="block text-sm font-medium text-gray-700 mb-1">Presenter Email</label>
-                            <input type="email" id="presenter_email" name="presenter_email" value="{{ old('presenter_email', $ttt->presenter_email) }}"
+                            <input type="email" id="presenter_email" name="presenter_email" value="{{ old('presenter_email', $ccl->presenter_email) }}"
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('presenter_email') border-red-300 @enderror">
                             @error('presenter_email')
@@ -106,7 +106,7 @@
                             <label for="presenter_bio" class="block text-sm font-medium text-gray-700 mb-1">Presenter Bio</label>
                             <textarea id="presenter_bio" name="presenter_bio" rows="3"
                                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
-                                             @error('presenter_bio') border-red-300 @enderror">{{ old('presenter_bio', $ttt->presenter_bio) }}</textarea>
+                                             @error('presenter_bio') border-red-300 @enderror">{{ old('presenter_bio', $ccl->presenter_bio) }}</textarea>
                             @error('presenter_bio')
                                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                             @enderror
@@ -114,7 +114,7 @@
 
                         <div>
                             <label for="co_presenter_name" class="block text-sm font-medium text-gray-700 mb-1">Co-Presenter Name(s)</label>
-                            <input type="text" id="co_presenter_name" name="co_presenter_name" value="{{ old('co_presenter_name', $ttt->co_presenter_name) }}"
+                            <input type="text" id="co_presenter_name" name="co_presenter_name" value="{{ old('co_presenter_name', $ccl->co_presenter_name) }}"
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('co_presenter_name') border-red-300 @enderror">
                             @error('co_presenter_name')
@@ -124,7 +124,7 @@
 
                         <div>
                             <label for="co_presenter_email" class="block text-sm font-medium text-gray-700 mb-1">Co-Presenter Email(s)</label>
-                            <input type="email" id="co_presenter_email" name="co_presenter_email" value="{{ old('co_presenter_email', $ttt->co_presenter_email) }}"
+                            <input type="email" id="co_presenter_email" name="co_presenter_email" value="{{ old('co_presenter_email', $ccl->co_presenter_email) }}"
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('co_presenter_email') border-red-300 @enderror">
                             @error('co_presenter_email')
@@ -147,7 +147,7 @@
                                            @error('p_d_day_id') border-red-300 @enderror">
                                 <option value="">Not assigned to any PL Day</option>
                                 @foreach($pdDays as $pdDay)
-                                    <option value="{{ $pdDay->id }}" {{ old('p_d_day_id', $ttt->p_d_day_id) == $pdDay->id ? 'selected' : '' }}>
+                                    <option value="{{ $pdDay->id }}" {{ old('p_d_day_id', $ccl->p_d_day_id) == $pdDay->id ? 'selected' : '' }}>
                                         {{ $pdDay->title }} ({{ $pdDay->date_range }})
                                     </option>
                                 @endforeach
@@ -161,7 +161,7 @@
                             <label for="date" class="block text-sm font-medium text-gray-700 mb-1">
                                 Date <span class="text-red-500">*</span>
                             </label>
-                            <input type="date" id="date" name="date" value="{{ old('date', $ttt->date->format('Y-m-d')) }}" required
+                            <input type="date" id="date" name="date" value="{{ old('date', $ccl->date->format('Y-m-d')) }}" required
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('date') border-red-300 @enderror">
                             @error('date')
@@ -173,7 +173,7 @@
                             <label for="start_time" class="block text-sm font-medium text-gray-700 mb-1">
                                 Start Time <span class="text-red-500">*</span>
                             </label>
-                            <input type="time" id="start_time" name="start_time" value="{{ old('start_time', $ttt->getRawOriginal('start_time')) }}" required
+                            <input type="time" id="start_time" name="start_time" value="{{ old('start_time', $ccl->getRawOriginal('start_time')) }}" required
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('start_time') border-red-300 @enderror">
                             @error('start_time')
@@ -185,7 +185,7 @@
                             <label for="end_time" class="block text-sm font-medium text-gray-700 mb-1">
                                 End Time <span class="text-red-500">*</span>
                             </label>
-                            <input type="time" id="end_time" name="end_time" value="{{ old('end_time', $ttt->getRawOriginal('end_time')) }}" required
+                            <input type="time" id="end_time" name="end_time" value="{{ old('end_time', $ccl->getRawOriginal('end_time')) }}" required
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('end_time') border-red-300 @enderror">
                             @error('end_time')
@@ -200,7 +200,7 @@
                                            @error('division_id') border-red-300 @enderror">
                                 <option value="">All Divisions</option>
                                 @foreach($divisions as $division)
-                                    <option value="{{ $division->id }}" {{ old('division_id', $ttt->division_id) == $division->id ? 'selected' : '' }}>
+                                    <option value="{{ $division->id }}" {{ old('division_id', $ccl->division_id) == $division->id ? 'selected' : '' }}>
                                         {{ $division->full_name }}
                                     </option>
                                 @endforeach
@@ -213,7 +213,7 @@
                         <div>
                             <label for="contact_hours" class="block text-sm font-medium text-gray-700 mb-1">Contact Hours</label>
                             <input type="number" id="contact_hours" name="contact_hours" 
-                                   value="{{ old('contact_hours', $ttt->contact_hours) }}" step="0.5" min="0" max="24"
+                                   value="{{ old('contact_hours', $ccl->contact_hours) }}" step="0.5" min="0" max="24"
                                    placeholder="Auto-calculated if empty"
                                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-aes-blue
                                           @error('contact_hours') border-red-300 @enderror">
@@ -230,7 +230,7 @@
                     <div class="space-y-4">
                         <div class="flex items-center">
                             <input type="checkbox" id="is_active" name="is_active" value="1"
-                                   {{ old('is_active', $ttt->is_active) ? 'checked' : '' }}
+                                   {{ old('is_active', $ccl->is_active) ? 'checked' : '' }}
                                    class="h-4 w-4 text-aes-blue border-gray-300 rounded focus:ring-aes-blue">
                             <label for="is_active" class="ml-2 text-sm text-gray-700">
                                 Session is active and available for enrollment
@@ -241,7 +241,7 @@
 
                 <!-- Submit Buttons -->
                 <div class="border-t pt-6 flex justify-end space-x-4">
-                    <a href="{{ route('admin.ttt.index') }}" 
+                    <a href="{{ route('admin.ccl.index') }}" 
                        class="px-6 py-3 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors font-medium">
                         Cancel
                     </a>
@@ -280,7 +280,7 @@
                                             {{ $enrollment->enrolled_at->format('g:i A') }}
                                         </p>
                                     </div>
-                                    <form action="{{ route('admin.ttt.remove-enrollment', $ttt) }}" method="POST" 
+                                    <form action="{{ route('admin.ccl.remove-enrollment', $ccl) }}" method="POST" 
                                           onsubmit="return confirm('Are you sure you want to remove {{ $enrollment->user->name }} from this session?')">
                                         @csrf
                                         <input type="hidden" name="user_id" value="{{ $enrollment->user->id }}">

--- a/resources/views/admin/ccl/index.blade.php
+++ b/resources/views/admin/ccl/index.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Manage TTT Sessions')
+@section('title', 'Manage CCL Sessions')
 
 @section('content')
 <div class="min-h-screen bg-gray-50 py-8">
@@ -9,17 +9,17 @@
         <div class="mb-8">
             <div class="flex justify-between items-start">
                 <div>
-                    <h1 class="text-3xl font-bold text-gray-900">Teachers Teaching Teachers</h1>
-                    <p class="mt-2 text-gray-600">Manage TTT sessions and track enrollments</p>
+                    <h1 class="text-3xl font-bold text-gray-900">Collaborative Community Learning Sessions</h1>
+                    <p class="mt-2 text-gray-600">Manage CCL sessions and track enrollments</p>
                 </div>
                 <div class="flex gap-3">
                     <button class="inline-flex items-center px-4 py-2 rounded-lg transition-colors shadow-sm font-medium
                                 {{ $settings->is_active ? 'bg-green-600 hover:bg-green-700 text-white' : 'bg-gray-300 hover:bg-gray-400 text-gray-700' }}" 
                             id="toggle-ttt-btn">
                         <i class="fas {{ $settings->is_active ? 'fa-toggle-on' : 'fa-toggle-off' }} mr-2"></i>
-                        TTT {{ $settings->is_active ? 'Active' : 'Inactive' }}
+                        CCL {{ $settings->is_active ? 'Active' : 'Inactive' }}
                     </button>
-                    <a href="{{ route('admin.ttt.create') }}" 
+                    <a href="{{ route('admin.ccl.create') }}" 
                        class="inline-flex items-center px-4 py-2 text-white rounded-lg transition-colors shadow-sm" style="background-color: var(--tlc-orange);" onmouseover="this.style.backgroundColor='#0d3b66'" onmouseout="this.style.backgroundColor='#ee964b'">
                         <i class="fas fa-plus mr-2"></i>
                         Add New Session
@@ -113,7 +113,7 @@
             <div class="px-6 py-4 border-b border-gray-200 bg-gray-50">
                 <div class="flex justify-between items-center">
                     <div>
-                        <h3 class="text-lg font-semibold text-gray-900">TTT Sessions</h3>
+                        <h3 class="text-lg font-semibold text-gray-900">CCL Sessions</h3>
                         <p class="text-sm text-gray-600 mt-1">
                             @if($sessions->count() > 0)
                                 Showing {{ $sessions->firstItem() }} to {{ $sessions->lastItem() }} of {{ $sessions->total() }} sessions
@@ -193,22 +193,22 @@
                                 </td>
                                 <td class="px-6 py-4 text-sm font-medium">
                                     <div class="flex space-x-3">
-                                        <a href="{{ route('admin.ttt.show', $session) }}" 
+                                        <a href="{{ route('admin.ccl.show', $session) }}" 
                                            class="text-aes-blue hover:text-blue-900 transition-colors" title="View Details">
                                             <i class="fas fa-eye"></i>
                                         </a>
-                                        <a href="{{ route('admin.ttt.edit', $session) }}" 
+                                        <a href="{{ route('admin.ccl.edit', $session) }}" 
                                            class="text-yellow-600 hover:text-yellow-900 transition-colors" title="Edit">
                                             <i class="fas fa-edit"></i>
                                         </a>
-                                        <form action="{{ route('admin.ttt.toggle-status', $session) }}" method="POST" class="inline">
+                                        <form action="{{ route('admin.ccl.toggle-status', $session) }}" method="POST" class="inline">
                                             @csrf
                                             <button type="submit" class="text-gray-600 hover:text-gray-900 transition-colors" 
                                                     title="{{ $session->is_active ? 'Deactivate' : 'Activate' }}">
                                                 <i class="fas fa-{{ $session->is_active ? 'pause' : 'play' }}"></i>
                                             </button>
                                         </form>
-                                        <form action="{{ route('admin.ttt.destroy', $session) }}" method="POST" 
+                                        <form action="{{ route('admin.ccl.destroy', $session) }}" method="POST" 
                                               class="inline" onsubmit="return confirm('Are you sure you want to delete this session?')">
                                             @csrf
                                             @method('DELETE')
@@ -224,9 +224,9 @@
                                 <td colspan="6" class="px-6 py-12 text-center text-gray-500">
                                     <div class="flex flex-col items-center">
                                         <i class="fas fa-chalkboard-teacher text-6xl text-gray-300 mb-6"></i>
-                                        <h3 class="text-lg font-medium text-gray-900 mb-2">No TTT sessions found</h3>
-                                        <p class="text-gray-500 mb-6">Get started by creating your first TTT session.</p>
-                                        <a href="{{ route('admin.ttt.create') }}" 
+                                        <h3 class="text-lg font-medium text-gray-900 mb-2">No CCL sessions found</h3>
+                                        <p class="text-gray-500 mb-6">Get started by creating your first CCL session.</p>
+                                        <a href="{{ route('admin.ccl.create') }}" 
                                            class="inline-flex items-center px-4 py-2 text-white rounded-lg transition-colors" style="background-color: var(--tlc-orange);" onmouseover="this.style.backgroundColor='#0d3b66'" onmouseout="this.style.backgroundColor='#ee964b'">
                                             <i class="fas fa-plus mr-2"></i>
                                             Add New Session
@@ -253,7 +253,7 @@
 <script>
 document.getElementById('toggle-ttt-btn').addEventListener('click', function() {
     const btn = this;
-    fetch('{{ route('admin.ttt.toggle-active') }}', {
+    fetch('{{ route('admin.ccl.toggle-active') }}', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -265,10 +265,10 @@ document.getElementById('toggle-ttt-btn').addEventListener('click', function() {
         if (data.success) {
             if (data.is_active) {
                 btn.className = 'inline-flex items-center px-4 py-2 rounded-lg transition-colors shadow-sm font-medium bg-green-600 hover:bg-green-700 text-white';
-                btn.innerHTML = '<i class="fas fa-toggle-on mr-2"></i> TTT Active';
+                btn.innerHTML = '<i class="fas fa-toggle-on mr-2"></i> CCL Active';
             } else {
                 btn.className = 'inline-flex items-center px-4 py-2 rounded-lg transition-colors shadow-sm font-medium bg-gray-300 hover:bg-gray-400 text-gray-700';
-                btn.innerHTML = '<i class="fas fa-toggle-off mr-2"></i> TTT Inactive';
+                btn.innerHTML = '<i class="fas fa-toggle-off mr-2"></i> CCL Inactive';
             }
         }
     });

--- a/resources/views/admin/ccl/show.blade.php
+++ b/resources/views/admin/ccl/show.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'TTT Session Details')
+@section('title', 'CCL Session Details')
 
 @section('content')
 <div class="min-h-screen bg-gray-50 py-8">
@@ -8,40 +8,40 @@
         <!-- Header -->
         <div class="mb-8">
             <div class="flex items-center justify-between mb-4">
-                <a href="{{ route('admin.ttt.index') }}" 
+                <a href="{{ route('admin.ccl.index') }}" 
                    class="hover:opacity-70" style="color: var(--tlc-navy);">
-                    <i class="fas fa-arrow-left mr-2"></i>Back to TTT Sessions
+                    <i class="fas fa-arrow-left mr-2"></i>Back to CCL Sessions
                 </a>
                 <div class="flex space-x-2">
-                    <a href="{{ route('admin.ttt.edit', $ttt) }}" 
+                    <a href="{{ route('admin.ccl.edit', $ccl) }}" 
                        class="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded-lg transition-colors">
                         <i class="fas fa-edit mr-2"></i>Edit Session
                     </a>
-                    <form action="{{ route('admin.ttt.toggle-status', $ttt) }}" method="POST" class="inline">
+                    <form action="{{ route('admin.ccl.toggle-status', $ccl) }}" method="POST" class="inline">
                         @csrf
                         <button type="submit" 
                                 class="px-4 py-2 rounded-lg text-white transition-colors
-                                       {{ $ttt->is_active ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700' }}">
-                            <i class="fas fa-{{ $ttt->is_active ? 'pause' : 'play' }} mr-2"></i>
-                            {{ $ttt->is_active ? 'Deactivate' : 'Activate' }}
+                                       {{ $ccl->is_active ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700' }}">
+                            <i class="fas fa-{{ $ccl->is_active ? 'pause' : 'play' }} mr-2"></i>
+                            {{ $ccl->is_active ? 'Deactivate' : 'Activate' }}
                         </button>
                     </form>
                 </div>
             </div>
-            <h1 class="text-3xl font-bold text-gray-900">{{ $ttt->title }}</h1>
+            <h1 class="text-3xl font-bold text-gray-900">{{ $ccl->title }}</h1>
             <div class="flex items-center mt-2 space-x-4">
                 <span class="px-3 py-1 text-sm font-semibold rounded-full 
-                            {{ $ttt->is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
-                    {{ $ttt->is_active ? 'Active' : 'Inactive' }}
+                            {{ $ccl->is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
+                    {{ $ccl->is_active ? 'Active' : 'Inactive' }}
                 </span>
-                @if($ttt->division)
+                @if($ccl->division)
                     <span class="px-3 py-1 text-sm bg-blue-100 text-blue-800 rounded-full">
-                        {{ $ttt->division->name }}
+                        {{ $ccl->division->name }}
                     </span>
                 @endif
-                @if($ttt->pdDay)
+                @if($ccl->pdDay)
                     <span class="px-3 py-1 text-sm bg-purple-100 text-purple-800 rounded-full">
-                        {{ $ttt->pdDay->title }}
+                        {{ $ccl->pdDay->title }}
                     </span>
                 @endif
             </div>
@@ -61,69 +61,69 @@
                 <div class="bg-white rounded-lg shadow p-6">
                     <h2 class="text-xl font-semibold text-gray-900 mb-4">Session Details</h2>
                     
-                    @if($ttt->description)
+                    @if($ccl->description)
                         <div class="mb-4">
                             <h3 class="text-sm font-medium text-gray-700 mb-2">Description</h3>
-                            <p class="text-gray-600 whitespace-pre-line">{{ $ttt->description }}</p>
+                            <p class="text-gray-600 whitespace-pre-line">{{ $ccl->description }}</p>
                         </div>
                     @endif
 
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div>
                             <h3 class="text-sm font-medium text-gray-700 mb-1">Date & Time</h3>
-                            <p class="text-gray-900">{{ $ttt->date->format('l, F j, Y') }}</p>
+                            <p class="text-gray-900">{{ $ccl->date->format('l, F j, Y') }}</p>
                             <p class="text-gray-600">
-                                @if($ttt->start_time && $ttt->end_time)
-                                    {{ $ttt->start_time->format('g:i A') }} - {{ $ttt->end_time->format('g:i A') }}
+                                @if($ccl->start_time && $ccl->end_time)
+                                    {{ $ccl->start_time->format('g:i A') }} - {{ $ccl->end_time->format('g:i A') }}
                                 @else
                                     <span class="text-gray-400">Not specified</span>
                                 @endif
                             </p>
                         </div>
 
-                        @if($ttt->location)
+                        @if($ccl->location)
                             <div>
                                 <h3 class="text-sm font-medium text-gray-700 mb-1">Location</h3>
-                                <p class="text-gray-900">{{ $ttt->location }}</p>
+                                <p class="text-gray-900">{{ $ccl->location }}</p>
                             </div>
                         @endif
 
                         <div>
                             <h3 class="text-sm font-medium text-gray-700 mb-1">Contact Hours</h3>
-                            <p class="text-gray-900">{{ $ttt->contact_hours ?: $ttt->calculateContactHours() }} hours</p>
+                            <p class="text-gray-900">{{ $ccl->contact_hours ?: $ccl->calculateContactHours() }} hours</p>
                         </div>
                     </div>
                 </div>
 
                 <!-- Presenter Information -->
-                @if($ttt->presenter_name || $ttt->presenter_bio || $ttt->presenter_email || $ttt->co_presenter_name || $ttt->co_presenter_email)
+                @if($ccl->presenter_name || $ccl->presenter_bio || $ccl->presenter_email || $ccl->co_presenter_name || $ccl->co_presenter_email)
                     <div class="bg-white rounded-lg shadow p-6">
                         <h2 class="text-xl font-semibold text-gray-900 mb-4">Presenter Information</h2>
                         
-                        @if($ttt->presenter_name)
+                        @if($ccl->presenter_name)
                             <div class="mb-4">
                                 <h3 class="text-sm font-medium text-gray-700 mb-2">Presenter Information</h3>
                                 <div class="bg-gray-50 rounded-lg p-4">
                                     <div class="mb-3">
                                         <h4 class="text-sm font-semibold text-gray-800 mb-1">Primary Presenter</h4>
-                                        <p class="text-gray-900 font-medium">{{ $ttt->presenter_name }}</p>
-                                        @if($ttt->presenter_email)
+                                        <p class="text-gray-900 font-medium">{{ $ccl->presenter_name }}</p>
+                                        @if($ccl->presenter_email)
                                             <p class="text-gray-600 text-sm">
-                                                <a href="mailto:{{ $ttt->presenter_email }}" class="hover:underline">
-                                                    {{ $ttt->presenter_email }}
+                                                <a href="mailto:{{ $ccl->presenter_email }}" class="hover:underline">
+                                                    {{ $ccl->presenter_email }}
                                                 </a>
                                             </p>
                                         @endif
                                     </div>
                                     
-                                    @if($ttt->co_presenter_name)
+                                    @if($ccl->co_presenter_name)
                                         <div class="border-t pt-3">
                                             <h4 class="text-sm font-semibold text-gray-800 mb-1">Co-Presenter(s)</h4>
-                                            <p class="text-gray-900 font-medium">{{ $ttt->co_presenter_name }}</p>
-                                            @if($ttt->co_presenter_email)
+                                            <p class="text-gray-900 font-medium">{{ $ccl->co_presenter_name }}</p>
+                                            @if($ccl->co_presenter_email)
                                                 <p class="text-gray-600 text-sm">
-                                                    <a href="mailto:{{ $ttt->co_presenter_email }}" class="hover:underline">
-                                                        {{ $ttt->co_presenter_email }}
+                                                    <a href="mailto:{{ $ccl->co_presenter_email }}" class="hover:underline">
+                                                        {{ $ccl->co_presenter_email }}
                                                     </a>
                                                 </p>
                                             @endif
@@ -133,21 +133,21 @@
                             </div>
                         @endif
 
-                        @if($ttt->presenter_bio)
+                        @if($ccl->presenter_bio)
                             <div>
                                 <h3 class="text-sm font-medium text-gray-700 mb-1">Bio</h3>
-                                <p class="text-gray-600 whitespace-pre-line">{{ $ttt->presenter_bio }}</p>
+                                <p class="text-gray-600 whitespace-pre-line">{{ $ccl->presenter_bio }}</p>
                             </div>
                         @endif
                     </div>
                 @endif
 
                 <!-- Resources -->
-                @if($ttt->links->count() > 0)
+                @if($ccl->links->count() > 0)
                     <div class="bg-white rounded-lg shadow p-6">
                         <h2 class="text-xl font-semibold text-gray-900 mb-4">Resources</h2>
                         <div class="space-y-3">
-                            @foreach($ttt->links as $link)
+                            @foreach($ccl->links as $link)
                                 <a href="{{ $link->formatted_url }}" target="_blank" 
                                    class="block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
                                     <div class="flex items-center">
@@ -198,22 +198,22 @@
                     <h2 class="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
                     
                     <div class="space-y-3">
-                        <a href="{{ route('admin.ttt.edit', $ttt) }}" 
+                        <a href="{{ route('admin.ccl.edit', $ccl) }}" 
                            class="block w-full text-center bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded-lg transition-colors">
                             <i class="fas fa-edit mr-2"></i>Edit Session
                         </a>
                         
-                        <form action="{{ route('admin.ttt.toggle-status', $ttt) }}" method="POST">
+                        <form action="{{ route('admin.ccl.toggle-status', $ccl) }}" method="POST">
                             @csrf
                             <button type="submit" 
                                     class="w-full px-4 py-2 rounded-lg text-white transition-colors
-                                           {{ $ttt->is_active ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700' }}">
-                                <i class="fas fa-{{ $ttt->is_active ? 'pause' : 'play' }} mr-2"></i>
-                                {{ $ttt->is_active ? 'Deactivate' : 'Activate' }}
+                                           {{ $ccl->is_active ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700' }}">
+                                <i class="fas fa-{{ $ccl->is_active ? 'pause' : 'play' }} mr-2"></i>
+                                {{ $ccl->is_active ? 'Deactivate' : 'Activate' }}
                             </button>
                         </form>
 
-                        <form action="{{ route('admin.ttt.destroy', $ttt) }}" method="POST" 
+                        <form action="{{ route('admin.ccl.destroy', $ccl) }}" method="POST" 
                               onsubmit="return confirm('Are you sure you want to delete this session? This action cannot be undone.')">
                             @csrf
                             @method('DELETE')
@@ -232,9 +232,9 @@
                     <div class="space-y-3">
                         <div>
                             <h3 class="text-sm font-medium text-gray-700 mb-1">PD Day</h3>
-                            @if($ttt->pdDay)
+                            @if($ccl->pdDay)
                                 <span class="px-3 py-1 text-sm bg-purple-100 text-purple-800 rounded-full">
-                                    {{ $ttt->pdDay->title }}
+                                    {{ $ccl->pdDay->title }}
                                 </span>
                             @else
                                 <p class="text-gray-500 text-sm">Not assigned</p>
@@ -243,9 +243,9 @@
 
                         <div>
                             <h3 class="text-sm font-medium text-gray-700 mb-1">Division</h3>
-                            @if($ttt->division)
+                            @if($ccl->division)
                                 <span class="px-3 py-1 text-sm bg-blue-100 text-blue-800 rounded-full">
-                                    {{ $ttt->division->full_name }}
+                                    {{ $ccl->division->full_name }}
                                 </span>
                             @else
                                 <p class="text-gray-500 text-sm">All Divisions</p>
@@ -283,7 +283,7 @@
                                             {{ $enrollment->enrolled_at->format('g:i A') }}
                                         </p>
                                     </div>
-                                    <form action="{{ route('admin.ttt.remove-enrollment', $ttt) }}" method="POST" 
+                                    <form action="{{ route('admin.ccl.remove-enrollment', $ccl) }}" method="POST" 
                                           onsubmit="return confirm('Are you sure you want to remove {{ $enrollment->user->name }} from this session?')">
                                         @csrf
                                         <input type="hidden" name="user_id" value="{{ $enrollment->user->id }}">

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -248,9 +248,9 @@
                                                         Wellness
                                                     </span>
                                                 @elseif($enrollment->scheduleItem)
-                                                    @if($enrollment->scheduleItem->session_type === 'ttt')
+                                                    @if($enrollment->scheduleItem->session_type === 'ccl')
                                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-                                                            TTT
+                                                            CCL
                                                         </span>
                                                     @else
                                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
@@ -296,17 +296,17 @@
                                                             <i class="fas fa-times"></i>
                                                         </button>
                                                     </form>
-                                                @elseif($enrollment->scheduleItem && $enrollment->scheduleItem->session_type === 'ttt' && $enrollment->status !== 'cancelled')
+                                                @elseif($enrollment->scheduleItem && $enrollment->scheduleItem->session_type === 'ccl' && $enrollment->status !== 'cancelled')
                                                     @php
-                                                        $tttSession = \App\Models\TTTSession::where('p_d_day_id', $enrollment->scheduleItem->p_d_day_id)
+                                                        $cclSession = \App\Models\CCLSession::where('p_d_day_id', $enrollment->scheduleItem->p_d_day_id)
                                                             ->where('date', $enrollment->scheduleItem->date)
                                                             ->whereTime('start_time', $enrollment->scheduleItem->start_time->format('H:i:s'))
                                                             ->where('title', $enrollment->scheduleItem->title)
                                                             ->first();
                                                     @endphp
-                                                    @if($tttSession)
-                                                        <form action="{{ route('admin.ttt.remove-enrollment', $tttSession) }}" method="POST" 
-                                                              onsubmit="return confirm('Are you sure you want to remove this user from this TTT session?')" class="inline">
+                                                    @if($cclSession)
+                                                        <form action="{{ route('admin.ccl.remove-enrollment', $cclSession) }}" method="POST" 
+                                                              onsubmit="return confirm('Are you sure you want to remove this user from this CCL session?')" class="inline">
                                                             @csrf
                                                             <input type="hidden" name="user_id" value="{{ $user->id }}">
                                                             <button type="submit" 

--- a/resources/views/archive/index.blade.php
+++ b/resources/views/archive/index.blade.php
@@ -144,7 +144,7 @@
                         </div>
                         <div class="bg-gray-50 rounded-lg p-3 text-center">
                             <div class="text-2xl font-bold text-tlc-navy">{{ $pdDay->tttSessions->count() }}</div>
-                            <div class="text-gray-500">TTT Sessions</div>
+                            <div class="text-gray-500">CCL Sessions</div>
                         </div>
                         <div class="bg-gray-50 rounded-lg p-3 text-center">
                             <div class="text-lg font-semibold text-gray-400">

--- a/resources/views/ccl/index.blade.php
+++ b/resources/views/ccl/index.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.user')
 
-@section('title', 'Teachers Teaching Teachers - TLC Professional Learning')
+@section('title', 'Collaborative Community Learning Sessions - TLC Professional Learning')
 
 @section('content')
 <style>
@@ -185,7 +185,7 @@
             $endTime = $firstSession->end_time;
         @endphp
         
-        <!-- TTT Session {{ $sessionNumber }} Header -->
+        <!-- CCL Session {{ $sessionNumber }} Header -->
         <div class="mb-4 mt-{{ $sessionNumber > 1 ? '10' : '0' }}">
             <div class="session-header-card rounded-2xl shadow-lg overflow-hidden" style="border: 3px solid {{ $sessionNumber === 1 ? '#f4d35e' : '#ee964b' }};">
                 <div class="px-6 py-5" style="background: linear-gradient(135deg, {{ $sessionNumber === 1 ? '#0d3b66 0%, #1a5490 100%' : '#7c2d12 0%, #9a3412 100%' }});">
@@ -196,7 +196,7 @@
                             </div>
                             <div>
                                 <h2 class="text-2xl font-black tracking-wide" style="color: {{ $sessionNumber === 1 ? '#f4d35e' : '#fed7aa' }}; text-shadow: 1px 1px 2px rgba(0,0,0,0.3);">
-                                    TTT SESSION {{ $sessionNumber }}
+                                    CCL SESSION {{ $sessionNumber }}
                                 </h2>
                                 <p class="text-base font-semibold mt-1" style="color: white;">
                                     <i class="fas fa-calendar-alt mr-2"></i>{{ $sessionDate->format('l, F j, Y') }}
@@ -220,10 +220,10 @@
             @php
                 $isEnrolled = isset($userEnrollments[$session->id]) && $userEnrollments[$session->id];
                 // Find corresponding schedule item to check capacity
-                // Match by title and session_type since TTT sessions are unique by title within the PD day
+                // Match by title and session_type since CCL sessions are unique by title within the PD day
                 $scheduleItem = \App\Models\ScheduleItem::where('p_d_day_id', $session->p_d_day_id)
                     ->where('title', $session->title)
-                    ->where('session_type', 'ttt')
+                    ->where('session_type', 'ccl')
                     ->whereDate('date', $session->date)
                     ->first();
                 $currentEnrollment = $scheduleItem ? $scheduleItem->current_enrollment : 0;
@@ -291,7 +291,7 @@
                     @endif
                 </div>
                 <div class="ttt-card-footer">
-                    <a href="{{ route('spring.ttt.show', $session) }}" class="view-btn">
+                    <a href="{{ route('spring.ccl.show', $session) }}" class="view-btn">
                         <i class="fas fa-eye mr-1"></i>View Details
                     </a>
                     @if($isEnrolled)
@@ -303,7 +303,7 @@
                             <i class="fas fa-times mr-1"></i>Full
                         </button>
                     @else
-                        <form action="{{ route('spring.ttt.join', $session) }}" method="POST" style="display: inline;">
+                        <form action="{{ route('spring.ccl.join', $session) }}" method="POST" style="display: inline;">
                             @csrf
                             <button type="submit" class="join-btn">
                                 <i class="fas fa-user-plus mr-1"></i>Join Session
@@ -320,8 +320,8 @@
         @else
         <div class="empty-state">
             <div class="text-5xl mb-4">👨‍🏫</div>
-            <h3 class="text-xl font-semibold text-gray-700 mb-2">No TTT Sessions Available</h3>
-            <p class="text-gray-500">Teachers Teaching Teachers sessions will be posted here when available.</p>
+            <h3 class="text-xl font-semibold text-gray-700 mb-2">No CCL Sessions Available</h3>
+            <p class="text-gray-500">Collaborative Community Learning Sessions sessions will be posted here when available.</p>
         </div>
         @endif
     </div>

--- a/resources/views/ccl/show.blade.php
+++ b/resources/views/ccl/show.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.user')
 
-@section('title', $session->title . ' - TTT')
+@section('title', $session->title . ' - CCL')
 
 @section('content')
 <style>
@@ -215,9 +215,9 @@
 
 <div class="min-h-screen" style="background-color: var(--tlc-cream);">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <a href="{{ route('spring.ttt') }}" class="back-link">
+        <a href="{{ route('spring.ccl') }}" class="back-link">
             <i class="fas fa-arrow-left"></i>
-            Back to TTT Sessions
+            Back to CCL Sessions
         </a>
 
         <div class="session-detail-card">
@@ -324,7 +324,7 @@
                             ->where('date', $session->date)
                             ->where('start_time', $session->start_time)
                             ->where('title', $session->title)
-                            ->where('session_type', 'ttt')
+                            ->where('session_type', 'ccl')
                             ->first();
                         $isFull = $scheduleItem && $scheduleItem->max_participants !== null && $scheduleItem->current_enrollment >= $scheduleItem->max_participants;
                     @endphp
@@ -337,7 +337,7 @@
                             <i class="fas fa-times mr-1"></i>Full
                         </button>
                     @else
-                        <form action="{{ route('spring.ttt.join', $session) }}" method="POST" style="display: inline;">
+                        <form action="{{ route('spring.ccl.join', $session) }}" method="POST" style="display: inline;">
                             @csrf
                             <button type="submit" class="btn btn-primary">
                                 <i class="fas fa-user-plus mr-1"></i>Join Session

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -162,9 +162,9 @@
                                class="text-white hover:text-gray-200 {{ request()->routeIs('admin.schedule.*') ? 'font-medium underline underline-offset-4' : '' }}">
                                 Schedule
                             </a>
-                            <a href="{{ route('admin.ttt.index') }}" 
-                               class="text-white hover:text-gray-200 {{ request()->routeIs('admin.ttt.*') ? 'font-medium underline underline-offset-4' : '' }}">
-                                TTT
+                            <a href="{{ route('admin.ccl.index') }}" 
+                               class="text-white hover:text-gray-200 {{ request()->routeIs('admin.ccl.*') ? 'font-medium underline underline-offset-4' : '' }}">
+                                CCL
                             </a>
                             <a href="{{ route('admin.users.index') }}" 
                                class="text-white hover:text-gray-200 {{ request()->routeIs('admin.users.*') ? 'font-medium underline underline-offset-4' : '' }}">
@@ -208,9 +208,9 @@
                            class="block px-3 py-2 text-base font-medium text-white hover:text-gray-200 hover:bg-white/10 rounded-md {{ request()->routeIs('admin.schedule.*') ? 'bg-white/10' : '' }}">
                             Schedule
                         </a>
-                        <a href="{{ route('admin.ttt.index') }}"
-                           class="block px-3 py-2 text-base font-medium text-white hover:text-gray-200 hover:bg-white/10 rounded-md {{ request()->routeIs('admin.ttt.*') ? 'bg-white/10' : '' }}">
-                            TTT
+                        <a href="{{ route('admin.ccl.index') }}"
+                           class="block px-3 py-2 text-base font-medium text-white hover:text-gray-200 hover:bg-white/10 rounded-md {{ request()->routeIs('admin.ccl.*') ? 'bg-white/10' : '' }}">
+                            CCL
                         </a>
                         <a href="{{ route('admin.users.index') }}"
                            class="block px-3 py-2 text-base font-medium text-white hover:text-gray-200 hover:bg-white/10 rounded-md {{ request()->routeIs('admin.users.*') ? 'bg-white/10' : '' }}">

--- a/resources/views/layouts/user.blade.php
+++ b/resources/views/layouts/user.blade.php
@@ -398,9 +398,9 @@
                             <a href="{{ route('spring.wellness') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.wellness') ? 'text-tlc-gold font-semibold' : '' }}">
                                 Wellness
                             </a>
-                            @if($tttActive ?? false)
-                            <a href="{{ route('spring.ttt') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.ttt') ? 'text-tlc-gold font-semibold' : '' }}">
-                                TTT
+                            @if($cclActive ?? false)
+                            <a href="{{ route('spring.ccl') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.ccl') ? 'text-tlc-gold font-semibold' : '' }}">
+                                CCL
                             </a>
                             @endif
                             @if(isset($archivedSpringPDDays) && $archivedSpringPDDays->count() > 0)
@@ -488,10 +488,10 @@
                    class="sub-nav-item {{ request()->routeIs('spring.wellness') ? 'active' : '' }}">
                     Wellness
                 </a>
-                @if($tttActive ?? false)
-                <a href="{{ route('spring.ttt') }}"
-                   class="sub-nav-item {{ request()->routeIs('spring.ttt') ? 'active' : '' }}">
-                    TTT
+                @if($cclActive ?? false)
+                <a href="{{ route('spring.ccl') }}"
+                   class="sub-nav-item {{ request()->routeIs('spring.ccl') ? 'active' : '' }}">
+                    CCL
                 </a>
                 @endif
                 @if(isset($archivedSpringPDDays) && $archivedSpringPDDays->count() > 0)

--- a/resources/views/my-pl/index.blade.php
+++ b/resources/views/my-pl/index.blade.php
@@ -193,7 +193,7 @@
                     <div class="stat-label">Wellness</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number">{{ count($groupedSessions['pl_wednesday']) + count($groupedSessions['ttt']) }}</div>
+                    <div class="stat-number">{{ count($groupedSessions['pl_wednesday']) + count($groupedSessions['ccl']) }}</div>
                     <div class="stat-label">Other</div>
                 </div>
             </div>
@@ -312,17 +312,17 @@
             </div>
             @endif
 
-            <!-- TTT Sessions -->
-            @if(count($groupedSessions['ttt']) > 0)
+            <!-- CCL Sessions -->
+            @if(count($groupedSessions['ccl']) > 0)
             <div class="section-card">
                 <div class="section-header">
-                    <span><i class="fas fa-chalkboard-teacher mr-2"></i>Teachers Teaching Teachers</span>
+                    <span><i class="fas fa-chalkboard-teacher mr-2"></i>Collaborative Community Learning Sessions</span>
                     <span class="bg-white text-tlc-navy px-3 py-1 rounded-full text-sm font-bold">
-                        {{ count($groupedSessions['ttt']) }}
+                        {{ count($groupedSessions['ccl']) }}
                     </span>
                 </div>
                 <div class="session-list">
-                    @foreach($groupedSessions['ttt'] as $session)
+                    @foreach($groupedSessions['ccl'] as $session)
                     <div class="session-item">
                         <div class="session-info">
                             <div class="session-title">{{ $session->title }}</div>
@@ -336,7 +336,7 @@
                                 @endif
                             </div>
                         </div>
-                        <button class="remove-btn" onclick="toggleSession('ttt_session', {{ $session->id }})">
+                        <button class="remove-btn" onclick="toggleSession('ccl_session', {{ $session->id }})">
                             <i class="fas fa-times mr-1"></i>Remove
                         </button>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,12 +6,12 @@ use App\Http\Controllers\ScheduleController;
 use App\Http\Controllers\WellnessController;
 use App\Http\Controllers\PLWednesdayController;
 use App\Http\Controllers\MyPLController;
-use App\Http\Controllers\TTTController;
+use App\Http\Controllers\CCLController;
 use App\Http\Controllers\Admin\AdminController;
 use App\Http\Controllers\Admin\WellnessSessionController;
 use App\Http\Controllers\Admin\ScheduleItemController;
 use App\Http\Controllers\Admin\PLWednesdayController as AdminPLWednesdayController;
-use App\Http\Controllers\Admin\TTTController as AdminTTTController;
+use App\Http\Controllers\Admin\CCLController as AdminCCLController;
 use App\Http\Controllers\Admin\ReportsController;
 use App\Http\Controllers\Admin\PDDayController;
 use App\Http\Controllers\Admin\AdminAuthController;
@@ -65,9 +65,9 @@ Route::middleware(['user.only'])->group(function () {
         Route::get('/wellness', [WellnessController::class, 'springIndex'])->name('spring.wellness');
         Route::get('/wellness/{session}', [WellnessController::class, 'show'])->name('spring.wellness.show');
         Route::post('/wellness/{session}/enroll', [WellnessController::class, 'enroll'])->name('spring.wellness.enroll');
-        Route::get('/ttt', [TTTController::class, 'index'])->name('spring.ttt');
-        Route::get('/ttt/{session}', [TTTController::class, 'show'])->name('spring.ttt.show');
-        Route::post('/ttt/{session}/join', [TTTController::class, 'join'])->name('spring.ttt.join');
+        Route::get('/ccl', [CCLController::class, 'index'])->name('spring.ccl');
+        Route::get('/ccl/{session}', [CCLController::class, 'show'])->name('spring.ccl.show');
+        Route::post('/ccl/{session}/join', [CCLController::class, 'join'])->name('spring.ccl.join');
     });
 
     // Legacy Schedule routes (for backwards compatibility)
@@ -129,11 +129,11 @@ Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(fun
     Route::post('/pl-wednesday/{plWednesday}/toggle-status', [AdminPLWednesdayController::class, 'toggleSessionStatus'])->name('pl-wednesday.toggle-status');
     Route::resource('pl-wednesday', AdminPLWednesdayController::class);
     
-    // TTT (Teachers Teaching Teachers) Management
-    Route::post('/ttt/toggle-active', [AdminTTTController::class, 'toggleActive'])->name('ttt.toggle-active');
-    Route::post('/ttt/{ttt}/toggle-status', [AdminTTTController::class, 'toggleSessionStatus'])->name('ttt.toggle-status');
-    Route::post('/ttt/{ttt}/remove-enrollment', [AdminTTTController::class, 'removeEnrollment'])->name('ttt.remove-enrollment');
-    Route::resource('ttt', AdminTTTController::class);
+    // CCL (Collaborative Community Learning Sessions) Management
+    Route::post('/ccl/toggle-active', [AdminCCLController::class, 'toggleActive'])->name('ccl.toggle-active');
+    Route::post('/ccl/{ccl}/toggle-status', [AdminCCLController::class, 'toggleSessionStatus'])->name('ccl.toggle-status');
+    Route::post('/ccl/{ccl}/remove-enrollment', [AdminCCLController::class, 'removeEnrollment'])->name('ccl.remove-enrollment');
+    Route::resource('ccl', AdminCCLController::class);
     
     // Reports
     Route::get('/reports', [ReportsController::class, 'index'])->name('reports');

--- a/tests/Feature/AdminRemoveCCLEnrollmentTest.php
+++ b/tests/Feature/AdminRemoveCCLEnrollmentTest.php
@@ -4,16 +4,16 @@ namespace Tests\Feature;
 
 use Tests\TestCase;
 use App\Models\User;
-use App\Models\TTTSession;
+use App\Models\CCLSession;
 use App\Models\ScheduleItem;
 use App\Models\UserSession;
 use App\Models\PDDay;
 use App\Models\Division;
-use App\Models\TTTSetting;
+use App\Models\CCLSetting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Carbon\Carbon;
 
-class AdminRemoveTTTEnrollmentTest extends TestCase
+class AdminRemoveCCLEnrollmentTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -30,8 +30,8 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
             'is_active' => true,
         ]);
 
-        // Ensure TTT settings exist and are active
-        $settings = TTTSetting::firstOrCreate([], [
+        // Ensure CCL settings exist and are active
+        $settings = CCLSetting::firstOrCreate([], [
             'is_active' => true,
         ]);
         $settings->is_active = true;
@@ -67,13 +67,13 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
             'academic_year' => PDDay::getCurrentAcademicYear(),
         ]);
 
-        // Create a TTT session
+        // Create a CCL session
         $sessionDate = Carbon::now()->addDays(7);
         $startTime = Carbon::createFromTime(10, 0, 0);
         
-        $tttSession = TTTSession::create([
-            'title' => 'Test TTT Session',
-            'description' => 'A test TTT session',
+        $tttSession = CCLSession::create([
+            'title' => 'Test CCL Session',
+            'description' => 'A test CCL session',
             'presenter_name' => 'Test Presenter',
             'location' => 'Test Location',
             'date' => $sessionDate,
@@ -98,7 +98,7 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
             'date' => $tttSession->date,
             'presenter_primary' => $tttSession->presenter_name,
             'is_active' => true,
-            'session_type' => 'ttt',
+            'session_type' => 'ccl',
             'p_d_day_id' => $pdDay->id,
             'max_participants' => 20,
             'current_enrollment' => 0,
@@ -122,7 +122,7 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
 
         // Act as admin and remove the enrollment
         $response = $this->actingAs($admin)->post(
-            route('admin.ttt.remove-enrollment', $tttSession),
+            route('admin.ccl.remove-enrollment', $tttSession),
             [
                 'user_id' => $user->id,
             ]
@@ -170,13 +170,13 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
             'academic_year' => PDDay::getCurrentAcademicYear(),
         ]);
 
-        // Create a TTT session
+        // Create a CCL session
         $sessionDate = Carbon::now()->addDays(7);
         $startTime = Carbon::createFromTime(10, 0, 0);
         
-        $tttSession = TTTSession::create([
-            'title' => 'Test TTT Session',
-            'description' => 'A test TTT session',
+        $tttSession = CCLSession::create([
+            'title' => 'Test CCL Session',
+            'description' => 'A test CCL session',
             'presenter_name' => 'Test Presenter',
             'location' => 'Test Location',
             'date' => $sessionDate,
@@ -201,13 +201,13 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
             'date' => $tttSession->date,
             'presenter_primary' => $tttSession->presenter_name,
             'is_active' => true,
-            'session_type' => 'ttt',
+            'session_type' => 'ccl',
             'p_d_day_id' => $pdDay->id,
         ]);
 
         // Attempt to remove user who is not enrolled
         $response = $this->actingAs($admin)->post(
-            route('admin.ttt.remove-enrollment', $tttSession),
+            route('admin.ccl.remove-enrollment', $tttSession),
             [
                 'user_id' => $user->id,
             ]
@@ -247,13 +247,13 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
             'academic_year' => PDDay::getCurrentAcademicYear(),
         ]);
 
-        // Create a TTT session
+        // Create a CCL session
         $sessionDate = Carbon::now()->addDays(7);
         $startTime = Carbon::createFromTime(10, 0, 0);
         
-        $tttSession = TTTSession::create([
-            'title' => 'Test TTT Session',
-            'description' => 'A test TTT session',
+        $tttSession = CCLSession::create([
+            'title' => 'Test CCL Session',
+            'description' => 'A test CCL session',
             'presenter_name' => 'Test Presenter',
             'location' => 'Test Location',
             'date' => $sessionDate,
@@ -278,7 +278,7 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
             'date' => $tttSession->date,
             'presenter_primary' => $tttSession->presenter_name,
             'is_active' => true,
-            'session_type' => 'ttt',
+            'session_type' => 'ccl',
             'p_d_day_id' => $pdDay->id,
         ]);
 
@@ -292,7 +292,7 @@ class AdminRemoveTTTEnrollmentTest extends TestCase
 
         // Attempt to remove enrollment as non-admin
         $response = $this->actingAs($regularUser)->post(
-            route('admin.ttt.remove-enrollment', $tttSession),
+            route('admin.ccl.remove-enrollment', $tttSession),
             [
                 'user_id' => $enrolledUser->id,
             ]

--- a/tests/Feature/FullSessionEnrollmentTest.php
+++ b/tests/Feature/FullSessionEnrollmentTest.php
@@ -4,13 +4,13 @@ namespace Tests\Feature;
 
 use Tests\TestCase;
 use App\Models\User;
-use App\Models\TTTSession;
+use App\Models\CCLSession;
 use App\Models\WellnessSession;
 use App\Models\ScheduleItem;
 use App\Models\UserSession;
 use App\Models\PDDay;
 use App\Models\Division;
-use App\Models\TTTSetting;
+use App\Models\CCLSetting;
 use App\Models\WellnessSetting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Carbon\Carbon;
@@ -32,8 +32,8 @@ class FullSessionEnrollmentTest extends TestCase
             'is_active' => true,
         ]);
 
-        // Ensure TTT settings exist and are active
-        $tttSettings = TTTSetting::firstOrCreate([], [
+        // Ensure CCL settings exist and are active
+        $tttSettings = CCLSetting::firstOrCreate([], [
             'is_active' => true,
         ]);
         $tttSettings->is_active = true;
@@ -127,13 +127,13 @@ class FullSessionEnrollmentTest extends TestCase
             'academic_year' => PDDay::getCurrentAcademicYear(),
         ]);
 
-        // Create a TTT session
+        // Create a CCL session
         $sessionDate = Carbon::now()->addDays(7);
         $startTime = Carbon::createFromTime(10, 0, 0);
         
-        $tttSession = TTTSession::create([
-            'title' => 'Full TTT Session',
-            'description' => 'A TTT session that is full',
+        $tttSession = CCLSession::create([
+            'title' => 'Full CCL Session',
+            'description' => 'A CCL session that is full',
             'presenter_name' => 'Test Presenter',
             'location' => 'Test Location',
             'date' => $sessionDate,
@@ -237,13 +237,13 @@ class FullSessionEnrollmentTest extends TestCase
             'academic_year' => PDDay::getCurrentAcademicYear(),
         ]);
 
-        // Create a TTT session
+        // Create a CCL session
         $sessionDate = Carbon::now()->addDays(7);
         $startTime = Carbon::createFromTime(10, 0, 0);
         
-        $tttSession = TTTSession::create([
-            'title' => 'Full TTT Session',
-            'description' => 'A TTT session at capacity',
+        $tttSession = CCLSession::create([
+            'title' => 'Full CCL Session',
+            'description' => 'A CCL session at capacity',
             'presenter_name' => 'Test Presenter',
             'location' => 'Test Location',
             'date' => $sessionDate,


### PR DESCRIPTION
This comprehensive refactoring updates all references throughout the application:

- Models: TTTSession, TTTSetting, TTTLink → CCLSession, CCLSetting, CCLLink
- Controllers: TTTController → CCLController (both user and admin)
- Routes: /ttt → /ccl, admin.ttt.* → admin.ccl.*
- Migrations: ttt_* tables → ccl_* tables
- Views: ttt/ → ccl/, updated all template references
- Seeders: TTTSessionSeeder → CCLSessionSeeder
- Tests: AdminRemoveTTTEnrollmentTest → AdminRemoveCCLEnrollmentTest
- Integration points: AppServiceProvider, MyPLController, PDDay model
- Documentation: Updated CLAUDE.md

All references to "Teachers Teaching Teachers" have been replaced with
"Collaborative Community Learning Sessions" throughout the codebase.