### PR TITLE
feat: Earth Day Mini-PL Workshops

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use App\Models\User;
 use App\Models\ScheduleItem;
 use App\Models\WellnessSession;
 use App\Models\Division;
 use App\Models\UserSession;
+use App\Models\EarthDaySetting;
 use Carbon\Carbon;
 
 class AdminController extends Controller
@@ -89,6 +91,87 @@ class AdminController extends Controller
         $divisions = Division::all();
 
         return view('admin.users.index', compact('users', 'divisions'));
+    }
+
+    /**
+     * Show form to manually add a user
+     */
+    public function createUser()
+    {
+        $divisions = Division::all();
+
+        return view('admin.users.create', compact('divisions'));
+    }
+
+    /**
+     * Store a manually added user
+     */
+    public function storeUser(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'division_id' => 'nullable|exists:divisions,id',
+            'id_card_code' => 'nullable|string|max:255|unique:users,id_card_code',
+            'is_admin' => 'boolean',
+            'is_active' => 'boolean',
+        ]);
+
+        $divisionId = $validated['division_id']
+            ?? User::detectDivisionFromEmail($validated['email']);
+
+        // Placeholder password (users sign in with Google)
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => \Hash::make(\Str::random(32)),
+            'division_id' => $divisionId,
+            'id_card_code' => ! empty($validated['id_card_code'] ?? null) ? $validated['id_card_code'] : null,
+            'is_admin' => $request->boolean('is_admin'),
+            'is_active' => $request->boolean('is_active', true),
+        ]);
+
+        return redirect()
+            ->route('admin.users.show', $user)
+            ->with('success', 'User "' . $user->name . '" has been added.');
+    }
+
+    /**
+     * Show form to edit a user
+     */
+    public function editUser(User $user)
+    {
+        $divisions = Division::all();
+
+        return view('admin.users.edit', compact('user', 'divisions'));
+    }
+
+    /**
+     * Update a user
+     */
+    public function updateUser(Request $request, User $user)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => ['required', 'email', Rule::unique('users', 'email')->ignore($user->id)],
+            'division_id' => 'nullable|exists:divisions,id',
+            'id_card_code' => ['nullable', 'string', 'max:255', Rule::unique('users', 'id_card_code')->ignore($user->id)],
+            'is_admin' => 'boolean',
+            'is_active' => 'boolean',
+        ]);
+
+        $user->update([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'division_id' => $validated['division_id'] ?: null,
+            'id_card_code' => ! empty($validated['id_card_code'] ?? null) ? $validated['id_card_code'] : null,
+            'is_admin' => $request->boolean('is_admin'),
+            'is_active' => $request->boolean('is_active'),
+        ]);
+
+        return redirect()
+            ->route('admin.users.show', $user)
+            ->with('success', 'User "' . $user->name . '" has been updated.');
     }
 
     /**
@@ -226,11 +309,26 @@ class AdminController extends Controller
     {
         PLDaysSetting::initialize();
         $settings = PLDaysSetting::getActive();
-        
+
         $settings->update(['is_active' => !$settings->is_active]);
-        
+
         $status = $settings->is_active ? 'activated' : 'deactivated';
-        
+
         return back()->with('success', "PL Days feature {$status} successfully!");
+    }
+
+    /**
+     * Toggle Earth Day feature activation
+     */
+    public function toggleEarthDay()
+    {
+        EarthDaySetting::initialize();
+        $settings = EarthDaySetting::getActive();
+
+        $settings->update(['is_active' => !$settings->is_active]);
+
+        $status = $settings->is_active ? 'activated' : 'deactivated';
+
+        return back()->with('success', "Earth Day feature {$status} successfully!");
     }
 }

--- a/app/Http/Controllers/Admin/EarthDayController.php
+++ b/app/Http/Controllers/Admin/EarthDayController.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\EarthDayEnrollment;
+use App\Models\EarthDayWorkshop;
+use App\Models\EarthDaySetting;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class EarthDayController extends Controller
+{
+    public function index()
+    {
+        $workshops = EarthDayWorkshop::withCount('enrollments')
+            ->orderBy('title')
+            ->paginate(20);
+
+        $totalWorkshops   = EarthDayWorkshop::count();
+        $totalEnrolled    = EarthDayEnrollment::count();
+        $totalCapacity    = EarthDayWorkshop::where('is_active', true)->count() * EarthDayWorkshop::CAPACITY;
+        $spotsRemaining   = max(0, $totalCapacity - $totalEnrolled);
+
+        EarthDaySetting::initialize();
+        $featureActive = EarthDaySetting::isActive();
+
+        return view('admin.earth-day.index', compact(
+            'workshops',
+            'totalWorkshops',
+            'totalEnrolled',
+            'spotsRemaining',
+            'featureActive'
+        ));
+    }
+
+    public function create()
+    {
+        return view('admin.earth-day.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title'      => 'required|string|max:255',
+            'presenter'  => 'nullable|string|max:255',
+            'location'   => 'nullable|string|max:255',
+            'description'=> 'nullable|string',
+            'date'       => 'required|date',
+            'start_time' => 'required',
+            'end_time'   => 'required',
+            'is_active'  => 'boolean',
+        ]);
+
+        $validated['is_active'] = $request->has('is_active');
+
+        EarthDayWorkshop::create($validated);
+
+        return redirect()->route('admin.earth-day.index')
+            ->with('success', 'Workshop created successfully!');
+    }
+
+    public function show(EarthDayWorkshop $earthDay)
+    {
+        $earthDay->load(['enrollments.user.division']);
+
+        return view('admin.earth-day.show', compact('earthDay'));
+    }
+
+    public function edit(EarthDayWorkshop $earthDay)
+    {
+        $earthDay->load(['enrollments.user.division']);
+
+        return view('admin.earth-day.edit', compact('earthDay'));
+    }
+
+    public function update(Request $request, EarthDayWorkshop $earthDay)
+    {
+        $validated = $request->validate([
+            'title'      => 'required|string|max:255',
+            'presenter'  => 'nullable|string|max:255',
+            'location'   => 'nullable|string|max:255',
+            'description'=> 'nullable|string',
+            'date'       => 'required|date',
+            'start_time' => 'required',
+            'end_time'   => 'required',
+            'is_active'  => 'boolean',
+        ]);
+
+        $validated['is_active'] = $request->has('is_active');
+
+        $earthDay->update($validated);
+
+        return redirect()->route('admin.earth-day.index')
+            ->with('success', 'Workshop updated successfully!');
+    }
+
+    public function destroy(EarthDayWorkshop $earthDay)
+    {
+        $earthDay->delete();
+
+        return redirect()->route('admin.earth-day.index')
+            ->with('success', 'Workshop deleted successfully!');
+    }
+
+    public function toggleStatus(EarthDayWorkshop $earthDay)
+    {
+        $earthDay->update(['is_active' => !$earthDay->is_active]);
+
+        $status = $earthDay->is_active ? 'activated' : 'deactivated';
+
+        return back()->with('success', "Workshop {$status} successfully!");
+    }
+
+    public function toggleActive()
+    {
+        EarthDaySetting::initialize();
+        $settings = EarthDaySetting::getActive();
+        $settings->update(['is_active' => !$settings->is_active]);
+
+        $status = $settings->is_active ? 'activated' : 'deactivated';
+
+        return back()->with('success', "Earth Day feature {$status} successfully!");
+    }
+
+    public function removeEnrollment(Request $request, EarthDayWorkshop $earthDay)
+    {
+        $request->validate(['user_id' => 'required|exists:users,id']);
+
+        $enrollment = EarthDayEnrollment::where('user_id', $request->user_id)
+            ->where('earth_day_workshop_id', $earthDay->id)
+            ->first();
+
+        if (!$enrollment) {
+            return back()->with('error', 'User is not enrolled in this workshop.');
+        }
+
+        $enrollment->delete();
+        $earthDay->decrement('current_enrollment');
+
+        $user = User::find($request->user_id);
+
+        return back()->with('success', "Removed {$user->name} from the workshop.");
+    }
+
+    public function export()
+    {
+        $workshops = EarthDayWorkshop::orderBy('title')->get();
+        $workshopIds = $workshops->pluck('id')->all();
+
+        $enrollments = EarthDayEnrollment::whereIn('earth_day_workshop_id', $workshopIds)
+            ->with('user.division')
+            ->orderBy('earth_day_workshop_id')
+            ->orderBy('enrolled_at')
+            ->get()
+            ->groupBy('earth_day_workshop_id');
+
+        $filename = 'earth-day-workshops-export-' . now()->format('Y-m-d') . '.csv';
+        $headers = [
+            'Content-Type'        => 'text/csv',
+            'Content-Disposition' => "attachment; filename=\"{$filename}\"",
+        ];
+
+        $callback = function () use ($workshops, $enrollments) {
+            $file = fopen('php://output', 'w');
+            fputcsv($file, ['Workshop Title', 'Presenter', 'Location', 'Participant Name', 'Participant Email', 'Division', 'Enrolled At']);
+
+            foreach ($workshops as $workshop) {
+                $participants = $enrollments->get($workshop->id) ?? collect();
+
+                if ($participants->isEmpty()) {
+                    fputcsv($file, [$workshop->title, $workshop->presenter ?? '', $workshop->location ?? '', '', '', '', '']);
+                } else {
+                    foreach ($participants as $enrollment) {
+                        $user = $enrollment->user;
+                        fputcsv($file, [
+                            $workshop->title,
+                            $workshop->presenter ?? '',
+                            $workshop->location ?? '',
+                            $user?->name ?? '',
+                            $user?->email ?? '',
+                            $user?->division?->name ?? '',
+                            $enrollment->enrolled_at?->format('M j, Y g:i A') ?? '',
+                        ]);
+                    }
+                }
+            }
+
+            fclose($file);
+        };
+
+        return response()->stream($callback, 200, $headers);
+    }
+}

--- a/app/Http/Controllers/EarthDayController.php
+++ b/app/Http/Controllers/EarthDayController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\EarthDayEnrollment;
+use App\Models\EarthDayWorkshop;
+use App\Models\EarthDaySetting;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class EarthDayController extends Controller
+{
+    public function index()
+    {
+        EarthDaySetting::initialize();
+        if (!EarthDaySetting::isActive()) {
+            abort(404);
+        }
+
+        $user = auth()->user();
+
+        $workshops = EarthDayWorkshop::active()
+            ->withCount('enrollments')
+            ->with(['enrollments' => fn($q) => $q->where('user_id', $user->id)])
+            ->orderBy('title')
+            ->get();
+
+        $userEnrollment = EarthDayEnrollment::where('user_id', $user->id)
+            ->with('workshop')
+            ->first();
+
+        return view('earth-day.index', compact('workshops', 'userEnrollment'));
+    }
+
+    public function enroll(Request $request, EarthDayWorkshop $workshop)
+    {
+        EarthDaySetting::initialize();
+        if (!EarthDaySetting::isActive()) {
+            abort(404);
+        }
+
+        $user = auth()->user();
+
+        // Already enrolled somewhere — lock them in
+        $existing = EarthDayEnrollment::where('user_id', $user->id)->first();
+        if ($existing) {
+            return back()->with('error', 'You have already chosen a workshop.');
+        }
+
+        try {
+            DB::transaction(function () use ($user, $workshop) {
+                $locked = EarthDayWorkshop::where('id', $workshop->id)->lockForUpdate()->first();
+
+                if ($locked->isFull()) {
+                    throw new \Exception('Sorry, this workshop is full.');
+                }
+
+                EarthDayEnrollment::create([
+                    'user_id'               => $user->id,
+                    'earth_day_workshop_id' => $locked->id,
+                    'enrolled_at'           => now(),
+                ]);
+
+                $locked->increment('current_enrollment');
+            });
+
+            return back()->with('success', 'You\'re registered! See you at Earth Day.');
+        } catch (\Exception $e) {
+            return back()->with('error', $e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/MyPLController.php
+++ b/app/Http/Controllers/MyPLController.php
@@ -8,6 +8,7 @@ use App\Models\ScheduleItem;
 use App\Models\WellnessSession;
 use App\Models\PLWednesdaySession;
 use App\Models\CCLSession;
+use App\Models\EarthDayWorkshop;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -50,6 +51,7 @@ class MyPLController extends Controller
             'wellness' => [],
             'pl_wednesday' => [],
             'ccl' => [],
+            'earth_day' => [],
         ];
 
         foreach ($selectedSessions as $selection) {
@@ -61,6 +63,7 @@ class MyPLController extends Controller
                 WellnessSession::class => 'wellness',
                 PLWednesdaySession::class => 'pl_wednesday',
                 CCLSession::class => 'ccl',
+                EarthDayWorkshop::class => 'earth_day',
                 default => null,
             };
             
@@ -119,6 +122,7 @@ class MyPLController extends Controller
             'wellness_session' => WellnessSession::class,
             'pl_wednesday_session' => PLWednesdaySession::class,
             'ccl_session' => CCLSession::class,
+            'earth_day_workshop' => EarthDayWorkshop::class,
         ];
 
         $class = $classMap[$type] ?? null;
@@ -204,6 +208,11 @@ class MyPLController extends Controller
                 $item['title'] = $session->title;
                 $item['presenter'] = $session->presenter_name ?? '';
                 $item['contact_hours'] = $session->contact_hours ?? $session->calculateContactHours();
+            } elseif ($session instanceof EarthDayWorkshop) {
+                $item['date'] = $session->date;
+                $item['title'] = $session->title;
+                $item['presenter'] = $session->presenter ?? '';
+                $item['contact_hours'] = 0.75; // 45-minute session
             }
 
             $transcriptItems[] = $item;

--- a/app/Models/EarthDayEnrollment.php
+++ b/app/Models/EarthDayEnrollment.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EarthDayEnrollment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'earth_day_workshop_id',
+        'enrolled_at',
+    ];
+
+    protected $casts = [
+        'enrolled_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function workshop(): BelongsTo
+    {
+        return $this->belongsTo(EarthDayWorkshop::class);
+    }
+}

--- a/app/Models/EarthDaySetting.php
+++ b/app/Models/EarthDaySetting.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EarthDaySetting extends Model
+{
+    use HasFactory;
+
+    protected $table = 'earth_day_settings';
+
+    protected $fillable = [
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public static function getActive()
+    {
+        return static::first();
+    }
+
+    public static function isActive(): bool
+    {
+        $setting = static::getActive();
+        return $setting && $setting->is_active;
+    }
+
+    public static function initialize()
+    {
+        if (!static::exists()) {
+            static::create(['is_active' => true]);
+        }
+    }
+}

--- a/app/Models/EarthDayWorkshop.php
+++ b/app/Models/EarthDayWorkshop.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+class EarthDayWorkshop extends Model
+{
+    use HasFactory;
+
+    const CAPACITY = 15;
+
+    protected $fillable = [
+        'title',
+        'presenter',
+        'location',
+        'description',
+        'date',
+        'start_time',
+        'end_time',
+        'current_enrollment',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+        'is_active' => 'boolean',
+    ];
+
+    public function enrollments(): HasMany
+    {
+        return $this->hasMany(EarthDayEnrollment::class);
+    }
+
+    public function userSelections(): MorphMany
+    {
+        return $this->morphMany(UserSelectedSession::class, 'selectable');
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function hasAvailableCapacity(): bool
+    {
+        return $this->current_enrollment < self::CAPACITY;
+    }
+
+    public function isFull(): bool
+    {
+        return $this->current_enrollment >= self::CAPACITY;
+    }
+
+    public function getFillPercentageAttribute(): int
+    {
+        return min(100, (int) round($this->current_enrollment / self::CAPACITY * 100));
+    }
+
+    public function getGoogleCalendarUrlAttribute(): string
+    {
+        $timezone = config('services.calendar.timezone', config('app.timezone', 'UTC'));
+
+        $dateStr = $this->date->format('Y-m-d');
+        $start = Carbon::createFromFormat('Y-m-d H:i:s', $dateStr . ' ' . $this->start_time, $timezone);
+        $end = Carbon::createFromFormat('Y-m-d H:i:s', $dateStr . ' ' . $this->end_time, $timezone);
+
+        if (!$start || !$end) {
+            return '';
+        }
+
+        $description = $this->description ?? '';
+        if ($this->presenter) {
+            $description .= ($description ? "\n\n" : '') . 'Presenter: ' . $this->presenter;
+        }
+
+        $params = [
+            'text'     => $this->title,
+            'dates'    => $start->format('Ymd\THis') . '/' . $end->format('Ymd\THis'),
+            'details'  => $description,
+            'location' => $this->location ?? '',
+            'ctz'      => $timezone,
+        ];
+
+        return 'https://calendar.google.com/calendar/render?action=TEMPLATE&' . http_build_query($params);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Models\PDDay;
 use App\Models\PLDaysSetting;
 use App\Models\PLWednesdaySetting;
 use App\Models\CCLSetting;
+use App\Models\EarthDaySetting;
 use App\Models\WellnessSetting;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -37,12 +38,14 @@ class AppServiceProvider extends ServiceProvider
             PLWednesdaySetting::initialize();
             WellnessSetting::initialize();
             PLDaysSetting::initialize();
+            EarthDaySetting::initialize();
 
             $view->with([
                 'plWednesdayActive' => PLWednesdaySetting::isActive(),
                 'wellnessActive' => WellnessSetting::isActive(),
                 'plDaysActive' => PLDaysSetting::isActive(),
                 'cclActive' => CCLSetting::isActive(),
+                'earthDayActive' => EarthDaySetting::isActive(),
                 'isNTSUser' => auth()->check() && auth()->user()->isNTS(),
                 'archivedFallPDDays' => PDDay::getArchivedBySeason('fall'),
                 'archivedSpringPDDays' => PDDay::getArchivedBySeason('spring'),

--- a/database/migrations/2026_04_08_000001_create_earth_day_settings_table.php
+++ b/database/migrations/2026_04_08_000001_create_earth_day_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('earth_day_settings', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('earth_day_settings');
+    }
+};

--- a/database/migrations/2026_04_08_000002_create_earth_day_workshops_table.php
+++ b/database/migrations/2026_04_08_000002_create_earth_day_workshops_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('earth_day_workshops', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('presenter')->nullable();
+            $table->string('location')->nullable();
+            $table->text('description')->nullable();
+            $table->date('date');
+            $table->time('start_time');
+            $table->time('end_time');
+            $table->integer('current_enrollment')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('earth_day_workshops');
+    }
+};

--- a/database/migrations/2026_04_08_000003_create_earth_day_enrollments_table.php
+++ b/database/migrations/2026_04_08_000003_create_earth_day_enrollments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('earth_day_enrollments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('earth_day_workshop_id')->constrained()->cascadeOnDelete();
+            $table->datetime('enrolled_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'earth_day_workshop_id']);
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('earth_day_enrollments');
+    }
+};

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -63,6 +63,11 @@
                            style="color: {{ request()->routeIs('admin.ccl.*') ? 'var(--tlc-gold)' : 'var(--tlc-cream)' }};">
                             CCL
                         </a>
+                        <a href="{{ route('admin.earth-day.index') }}"
+                           class="{{ request()->routeIs('admin.earth-day.*') ? 'font-medium' : '' }}"
+                           style="color: {{ request()->routeIs('admin.earth-day.*') ? 'var(--tlc-gold)' : 'var(--tlc-cream)' }};">
+                            Earth Day PL
+                        </a>
                         <a href="{{ route('admin.schedule.index') }}"
                            class="{{ request()->routeIs('admin.schedule.*') ? 'font-medium' : '' }}"
                            style="color: {{ request()->routeIs('admin.schedule.*') ? 'var(--tlc-gold)' : 'var(--tlc-cream)' }};">
@@ -158,6 +163,12 @@
                                         <i class="fas fa-plus text-white"></i>
                                     </div>
                                     <span class="text-sm font-medium" style="color: var(--tlc-orange);">CCL</span>
+                                </a>
+                                <a href="{{ route('admin.earth-day.create') }}" class="action-btn flex flex-col items-center p-4 rounded-xl border group" style="background: rgba(45, 106, 79, 0.1); border-color: rgba(45, 106, 79, 0.3);">
+                                    <div class="w-12 h-12 rounded-lg flex items-center justify-center mb-2 group-hover:scale-110 transition-transform" style="background: #2d6a4f;">
+                                        <i class="fas fa-plus text-white"></i>
+                                    </div>
+                                    <span class="text-sm font-medium" style="color: #2d6a4f;">Earth Day</span>
                                 </a>
                                 <a href="{{ route('admin.pl-wednesday.create') }}" class="action-btn flex flex-col items-center p-4 rounded-xl border group" style="background: rgba(13, 59, 102, 0.05); border-color: rgba(13, 59, 102, 0.2);">
                                     <div class="w-12 h-12 rounded-lg flex items-center justify-center mb-2 group-hover:scale-110 transition-transform" style="background: var(--tlc-navy);">

--- a/resources/views/admin/earth-day/create.blade.php
+++ b/resources/views/admin/earth-day/create.blade.php
@@ -1,0 +1,86 @@
+@extends('layouts.app')
+
+@section('title', 'New Earth Day Workshop')
+
+@section('content')
+<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+    <div class="mb-6">
+        <a href="{{ route('admin.earth-day.index') }}" class="text-gray-400 hover:text-gray-600 text-sm">← Earth Day PL</a>
+        <h1 class="text-xl font-bold text-tlc-navy mt-2">New Workshop</h1>
+    </div>
+
+    @if($errors->any())
+    <div class="mb-4 p-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm">
+        <ul class="list-disc list-inside space-y-1">
+            @foreach($errors->all() as $error)
+            <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+    @endif
+
+    <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+        <form method="POST" action="{{ route('admin.earth-day.store') }}" class="space-y-5">
+            @csrf
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Title <span class="text-red-500">*</span></label>
+                <input type="text" name="title" value="{{ old('title') }}" required
+                       class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+            </div>
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Presenter</label>
+                <input type="text" name="presenter" value="{{ old('presenter') }}"
+                       class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+            </div>
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Location</label>
+                <input type="text" name="location" value="{{ old('location') }}"
+                       class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+            </div>
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Description</label>
+                <textarea name="description" rows="4"
+                          class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">{{ old('description') }}</textarea>
+            </div>
+
+            <div class="grid grid-cols-3 gap-4">
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">Date <span class="text-red-500">*</span></label>
+                    <input type="date" name="date" value="{{ old('date', '2026-04-22') }}" required
+                           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+                </div>
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">Start Time <span class="text-red-500">*</span></label>
+                    <input type="time" name="start_time" value="{{ old('start_time', '15:40') }}" required
+                           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+                </div>
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">End Time <span class="text-red-500">*</span></label>
+                    <input type="time" name="end_time" value="{{ old('end_time', '16:25') }}" required
+                           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+                </div>
+            </div>
+
+            <div class="flex items-center gap-2">
+                <input type="checkbox" name="is_active" id="is_active" value="1"
+                       {{ old('is_active', true) ? 'checked' : '' }}
+                       class="w-4 h-4 accent-green-600">
+                <label for="is_active" class="text-sm font-medium text-gray-700">Active (visible to staff)</label>
+            </div>
+
+            <div class="flex items-center gap-3 pt-2">
+                <button type="submit" class="px-5 py-2 text-sm font-semibold btn-orange-to-navy rounded-lg btn-primary-action">
+                    Create Workshop
+                </button>
+                <a href="{{ route('admin.earth-day.index') }}" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Cancel</a>
+            </div>
+        </form>
+    </div>
+
+</div>
+@endsection

--- a/resources/views/admin/earth-day/edit.blade.php
+++ b/resources/views/admin/earth-day/edit.blade.php
@@ -1,0 +1,127 @@
+@extends('layouts.app')
+
+@section('title', 'Edit — ' . $earthDay->title)
+
+@section('content')
+<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+    <div class="mb-6">
+        <a href="{{ route('admin.earth-day.index') }}" class="text-gray-400 hover:text-gray-600 text-sm">← Earth Day PL</a>
+        <h1 class="text-xl font-bold text-tlc-navy mt-2">Edit Workshop</h1>
+    </div>
+
+    @if(session('success'))
+    <div class="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{{ session('success') }}</div>
+    @endif
+    @if(session('error'))
+    <div class="mb-4 p-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm">{{ session('error') }}</div>
+    @endif
+    @if($errors->any())
+    <div class="mb-4 p-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm">
+        <ul class="list-disc list-inside space-y-1">
+            @foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach
+        </ul>
+    </div>
+    @endif
+
+    <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-6 mb-6">
+        <form method="POST" action="{{ route('admin.earth-day.update', $earthDay) }}" class="space-y-5">
+            @csrf @method('PUT')
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Title <span class="text-red-500">*</span></label>
+                <input type="text" name="title" value="{{ old('title', $earthDay->title) }}" required
+                       class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+            </div>
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Presenter</label>
+                <input type="text" name="presenter" value="{{ old('presenter', $earthDay->presenter) }}"
+                       class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+            </div>
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Location</label>
+                <input type="text" name="location" value="{{ old('location', $earthDay->location) }}"
+                       class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+            </div>
+
+            <div>
+                <label class="block text-sm font-semibold text-gray-700 mb-1">Description</label>
+                <textarea name="description" rows="4"
+                          class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">{{ old('description', $earthDay->description) }}</textarea>
+            </div>
+
+            <div class="grid grid-cols-3 gap-4">
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">Date <span class="text-red-500">*</span></label>
+                    <input type="date" name="date" value="{{ old('date', $earthDay->date->format('Y-m-d')) }}" required
+                           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+                </div>
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">Start Time <span class="text-red-500">*</span></label>
+                    <input type="time" name="start_time" value="{{ old('start_time', \Carbon\Carbon::parse($earthDay->start_time)->format('H:i')) }}" required
+                           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+                </div>
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">End Time <span class="text-red-500">*</span></label>
+                    <input type="time" name="end_time" value="{{ old('end_time', \Carbon\Carbon::parse($earthDay->end_time)->format('H:i')) }}" required
+                           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500">
+                </div>
+            </div>
+
+            <div class="flex items-center gap-2">
+                <input type="checkbox" name="is_active" id="is_active" value="1"
+                       {{ old('is_active', $earthDay->is_active) ? 'checked' : '' }}
+                       class="w-4 h-4 accent-green-600">
+                <label for="is_active" class="text-sm font-medium text-gray-700">Active (visible to staff)</label>
+            </div>
+
+            <div class="flex items-center gap-3 pt-2">
+                <button type="submit" class="px-5 py-2 text-sm font-semibold btn-orange-to-navy rounded-lg btn-primary-action">
+                    Save Changes
+                </button>
+                <a href="{{ route('admin.earth-day.show', $earthDay) }}" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Cancel</a>
+            </div>
+        </form>
+    </div>
+
+    {{-- Participants (inline) --}}
+    @if($earthDay->enrollments->isNotEmpty())
+    <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-100">
+            <h2 class="font-semibold text-gray-800 text-sm">
+                Participants
+                <span class="text-gray-400 font-normal">({{ $earthDay->enrollments->count() }})</span>
+            </h2>
+        </div>
+        <table class="min-w-full divide-y divide-gray-100 text-sm">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600">Name</th>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600 hidden sm:table-cell">Email</th>
+                    <th class="px-4 py-3 text-right font-semibold text-gray-600">Remove</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+                @foreach($earthDay->enrollments as $enrollment)
+                <tr class="hover:bg-gray-50">
+                    <td class="px-4 py-3 font-medium text-gray-900">{{ $enrollment->user->name ?? '—' }}</td>
+                    <td class="px-4 py-3 text-gray-600 hidden sm:table-cell">{{ $enrollment->user->email ?? '—' }}</td>
+                    <td class="px-4 py-3 text-right">
+                        <form method="POST" action="{{ route('admin.earth-day.remove-enrollment', $earthDay) }}"
+                              onsubmit="return confirm('Remove {{ addslashes($enrollment->user->name ?? 'this user') }}?')">
+                            @csrf
+                            <input type="hidden" name="user_id" value="{{ $enrollment->user_id }}">
+                            <button type="submit" class="text-xs text-red-500 hover:text-red-700 font-medium">Remove</button>
+                        </form>
+                    </td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+    @endif
+
+</div>
+@endsection

--- a/resources/views/admin/earth-day/index.blade.php
+++ b/resources/views/admin/earth-day/index.blade.php
@@ -1,0 +1,148 @@
+@extends('layouts.app')
+
+@section('title', 'Earth Day PL - Admin')
+
+@section('content')
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+    {{-- Header --}}
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+        <div>
+            <h1 class="text-2xl font-bold text-tlc-navy">🌍 Earth Day PL Workshops</h1>
+            <p class="text-sm text-gray-500 mt-0.5">Manage workshops and view participant lists</p>
+        </div>
+        <div class="flex items-center gap-2 flex-wrap">
+            <a href="{{ route('admin.earth-day.export') }}"
+               class="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium bg-white border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
+                <i class="fas fa-download text-xs"></i> Export CSV
+            </a>
+            <a href="{{ route('admin.earth-day.create') }}"
+               class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-semibold btn-orange-to-navy rounded-lg">
+                <i class="fas fa-plus text-xs"></i> New Workshop
+            </a>
+        </div>
+    </div>
+
+    {{-- Flash --}}
+    @if(session('success'))
+    <div class="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{{ session('success') }}</div>
+    @endif
+    @if(session('error'))
+    <div class="mb-4 p-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm">{{ session('error') }}</div>
+    @endif
+
+    {{-- Feature toggle --}}
+    <div class="mb-6 p-4 bg-white rounded-xl border border-gray-200 shadow-sm flex items-center justify-between gap-4">
+        <div>
+            <p class="font-semibold text-gray-800 text-sm">Earth Day Feature Toggle</p>
+            <p class="text-xs text-gray-500 mt-0.5">
+                Currently: <span class="font-bold {{ $featureActive ? 'text-green-700' : 'text-red-600' }}">{{ $featureActive ? 'Active — tab visible to staff' : 'Inactive — tab hidden from staff' }}</span>
+            </p>
+        </div>
+        <form method="POST" action="{{ route('admin.earth-day.toggle-active') }}">
+            @csrf
+            <button type="submit"
+                    class="px-4 py-2 text-sm font-semibold rounded-lg border transition-colors
+                           {{ $featureActive ? 'border-red-300 text-red-700 hover:bg-red-50' : 'border-green-300 text-green-700 hover:bg-green-50' }}">
+                {{ $featureActive ? 'Deactivate' : 'Activate' }}
+            </button>
+        </form>
+    </div>
+
+    {{-- Stats --}}
+    <div class="grid grid-cols-3 gap-4 mb-6">
+        <div class="bg-white rounded-xl border border-gray-200 p-4 text-center shadow-sm">
+            <div class="text-2xl font-bold text-tlc-navy">{{ $totalWorkshops }}</div>
+            <div class="text-xs text-gray-500 mt-0.5 font-medium">Total Workshops</div>
+        </div>
+        <div class="bg-white rounded-xl border border-gray-200 p-4 text-center shadow-sm">
+            <div class="text-2xl font-bold text-green-700">{{ $totalEnrolled }}</div>
+            <div class="text-xs text-gray-500 mt-0.5 font-medium">Staff Registered</div>
+        </div>
+        <div class="bg-white rounded-xl border border-gray-200 p-4 text-center shadow-sm">
+            <div class="text-2xl font-bold text-tlc-orange">{{ $spotsRemaining }}</div>
+            <div class="text-xs text-gray-500 mt-0.5 font-medium">Spots Remaining</div>
+        </div>
+    </div>
+
+    {{-- Table --}}
+    <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <table class="min-w-full divide-y divide-gray-100 text-sm">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600">Workshop</th>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600 hidden md:table-cell">Location</th>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600 hidden lg:table-cell">Date / Time</th>
+                    <th class="px-4 py-3 text-center font-semibold text-gray-600">Enrolled</th>
+                    <th class="px-4 py-3 text-center font-semibold text-gray-600">Status</th>
+                    <th class="px-4 py-3 text-right font-semibold text-gray-600">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+                @forelse($workshops as $workshop)
+                <tr class="hover:bg-gray-50 transition-colors">
+                    <td class="px-4 py-3">
+                        <div class="font-semibold text-gray-900">{{ $workshop->title }}</div>
+                        @if($workshop->presenter)
+                        <div class="text-xs text-gray-500">{{ $workshop->presenter }}</div>
+                        @endif
+                    </td>
+                    <td class="px-4 py-3 text-gray-600 hidden md:table-cell">{{ $workshop->location ?? '—' }}</td>
+                    <td class="px-4 py-3 text-gray-600 hidden lg:table-cell">
+                        {{ $workshop->date->format('M j, Y') }}<br>
+                        <span class="text-xs">{{ \Carbon\Carbon::parse($workshop->start_time)->format('g:i A') }} – {{ \Carbon\Carbon::parse($workshop->end_time)->format('g:i A') }}</span>
+                    </td>
+                    <td class="px-4 py-3 text-center">
+                        <span class="{{ $workshop->enrollments_count >= \App\Models\EarthDayWorkshop::CAPACITY ? 'text-red-600 font-bold' : 'text-gray-700' }}">
+                            {{ $workshop->enrollments_count }}/{{ \App\Models\EarthDayWorkshop::CAPACITY }}
+                        </span>
+                    </td>
+                    <td class="px-4 py-3 text-center">
+                        <form method="POST" action="{{ route('admin.earth-day.toggle-status', $workshop) }}">
+                            @csrf
+                            <button type="submit"
+                                    class="text-xs font-semibold px-2 py-1 rounded-full border transition-colors
+                                           {{ $workshop->is_active ? 'bg-green-50 text-green-700 border-green-200 hover:bg-green-100' : 'bg-gray-100 text-gray-500 border-gray-200 hover:bg-gray-200' }}">
+                                {{ $workshop->is_active ? 'Active' : 'Inactive' }}
+                            </button>
+                        </form>
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                        <div class="flex items-center justify-end gap-1">
+                            <a href="{{ route('admin.earth-day.show', $workshop) }}"
+                               class="p-1.5 text-blue-600 hover:text-blue-800 rounded" title="View participants">
+                                <i class="fas fa-users text-xs"></i>
+                            </a>
+                            <a href="{{ route('admin.earth-day.edit', $workshop) }}"
+                               class="p-1.5 text-yellow-600 hover:text-yellow-800 rounded" title="Edit">
+                                <i class="fas fa-edit text-xs"></i>
+                            </a>
+                            <form method="POST" action="{{ route('admin.earth-day.destroy', $workshop) }}"
+                                  onsubmit="return confirm('Delete this workshop? This will remove all enrollments.')">
+                                @csrf @method('DELETE')
+                                <button type="submit" class="p-1.5 text-red-500 hover:text-red-700 rounded" title="Delete">
+                                    <i class="fas fa-trash text-xs"></i>
+                                </button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="6" class="px-4 py-10 text-center text-gray-400">
+                        No workshops yet. <a href="{{ route('admin.earth-day.create') }}" class="text-tlc-navy underline">Add the first one.</a>
+                    </td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+
+        @if($workshops->hasPages())
+        <div class="px-4 py-3 border-t border-gray-100">
+            {{ $workshops->links() }}
+        </div>
+        @endif
+    </div>
+
+</div>
+@endsection

--- a/resources/views/admin/earth-day/show.blade.php
+++ b/resources/views/admin/earth-day/show.blade.php
@@ -1,0 +1,112 @@
+@extends('layouts.app')
+
+@section('title', $earthDay->title . ' — Earth Day PL')
+
+@section('content')
+<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+    <div class="mb-6 flex items-center gap-3">
+        <a href="{{ route('admin.earth-day.index') }}" class="text-gray-400 hover:text-gray-600 text-sm">
+            ← Earth Day PL
+        </a>
+    </div>
+
+    {{-- Flash --}}
+    @if(session('success'))
+    <div class="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{{ session('success') }}</div>
+    @endif
+    @if(session('error'))
+    <div class="mb-4 p-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm">{{ session('error') }}</div>
+    @endif
+
+    {{-- Workshop details --}}
+    <div class="bg-white rounded-xl border border-gray-200 shadow-sm mb-6 overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-100 flex items-start justify-between gap-4">
+            <div>
+                <h1 class="text-xl font-bold text-tlc-navy">{{ $earthDay->title }}</h1>
+                @if($earthDay->presenter)
+                <p class="text-sm text-gray-500 mt-0.5">{{ $earthDay->presenter }}</p>
+                @endif
+            </div>
+            <a href="{{ route('admin.earth-day.edit', $earthDay) }}"
+               class="px-3 py-1.5 text-sm font-medium border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 whitespace-nowrap">
+                Edit
+            </a>
+        </div>
+        <div class="px-6 py-4 grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+            @if($earthDay->location)
+            <div>
+                <div class="text-xs text-gray-400 font-semibold uppercase tracking-wide mb-0.5">Location</div>
+                <div class="text-gray-800">{{ $earthDay->location }}</div>
+            </div>
+            @endif
+            <div>
+                <div class="text-xs text-gray-400 font-semibold uppercase tracking-wide mb-0.5">Date</div>
+                <div class="text-gray-800">{{ $earthDay->date->format('F j, Y') }}</div>
+            </div>
+            <div>
+                <div class="text-xs text-gray-400 font-semibold uppercase tracking-wide mb-0.5">Time</div>
+                <div class="text-gray-800">{{ \Carbon\Carbon::parse($earthDay->start_time)->format('g:i A') }} – {{ \Carbon\Carbon::parse($earthDay->end_time)->format('g:i A') }}</div>
+            </div>
+            <div>
+                <div class="text-xs text-gray-400 font-semibold uppercase tracking-wide mb-0.5">Enrollment</div>
+                <div class="font-semibold {{ $earthDay->isFull() ? 'text-red-600' : 'text-green-700' }}">
+                    {{ $earthDay->current_enrollment }} / {{ \App\Models\EarthDayWorkshop::CAPACITY }}
+                </div>
+            </div>
+        </div>
+        @if($earthDay->description)
+        <div class="px-6 pb-4 text-sm text-gray-600">{{ $earthDay->description }}</div>
+        @endif
+    </div>
+
+    {{-- Participants --}}
+    <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+            <h2 class="font-semibold text-gray-800">
+                Participants
+                <span class="ml-1.5 text-xs font-normal text-gray-400">({{ $earthDay->enrollments->count() }})</span>
+            </h2>
+        </div>
+
+        @if($earthDay->enrollments->isEmpty())
+        <div class="px-6 py-8 text-center text-gray-400 text-sm">No one has enrolled yet.</div>
+        @else
+        <table class="min-w-full divide-y divide-gray-100 text-sm">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600">Name</th>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600 hidden sm:table-cell">Email</th>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600 hidden md:table-cell">Division</th>
+                    <th class="px-4 py-3 text-left font-semibold text-gray-600 hidden lg:table-cell">Enrolled</th>
+                    <th class="px-4 py-3 text-right font-semibold text-gray-600">Remove</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+                @foreach($earthDay->enrollments as $enrollment)
+                <tr class="hover:bg-gray-50">
+                    <td class="px-4 py-3 font-medium text-gray-900">{{ $enrollment->user->name ?? '—' }}</td>
+                    <td class="px-4 py-3 text-gray-600 hidden sm:table-cell">{{ $enrollment->user->email ?? '—' }}</td>
+                    <td class="px-4 py-3 text-gray-600 hidden md:table-cell">{{ $enrollment->user->division->name ?? '—' }}</td>
+                    <td class="px-4 py-3 text-gray-500 text-xs hidden lg:table-cell">
+                        {{ $enrollment->enrolled_at?->format('M j, g:i A') ?? '—' }}
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                        <form method="POST" action="{{ route('admin.earth-day.remove-enrollment', $earthDay) }}"
+                              onsubmit="return confirm('Remove {{ addslashes($enrollment->user->name ?? 'this user') }} from this workshop?')">
+                            @csrf
+                            <input type="hidden" name="user_id" value="{{ $enrollment->user_id }}">
+                            <button type="submit" class="text-xs text-red-500 hover:text-red-700 font-medium">
+                                Remove
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+        @endif
+    </div>
+
+</div>
+@endsection

--- a/resources/views/earth-day/index.blade.php
+++ b/resources/views/earth-day/index.blade.php
@@ -1,0 +1,329 @@
+@extends('layouts.user')
+
+@section('title', 'Earth Day Mini-PL Workshops')
+
+@section('content')
+<style>
+:root {
+    --ed-green:       #2d6a4f;
+    --ed-green-light: #52b788;
+    --ed-green-dark:  #1b4332;
+    --ed-cream:       #f0faf4;
+}
+
+.ed-header {
+    background: linear-gradient(135deg, var(--ed-green-dark) 0%, var(--ed-green) 60%, #40916c 100%);
+    color: white;
+    padding: 2rem 1.5rem 1.75rem;
+}
+
+.ed-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+.ed-card {
+    background: white;
+    border-radius: 1rem;
+    box-shadow: 0 4px 12px rgba(27, 67, 50, 0.08);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (hover: hover) {
+    .ed-card:not(.greyed-out):hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 24px rgba(27, 67, 50, 0.14);
+    }
+}
+
+.ed-card-header {
+    background: linear-gradient(135deg, var(--ed-green) 0%, var(--ed-green-dark) 100%);
+    color: white;
+    padding: 1.25rem;
+}
+
+.ed-card-header h3 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 0.375rem;
+    line-height: 1.35;
+}
+
+.ed-card-body {
+    padding: 1.1rem 1.25rem 1.25rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.ed-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: #4b5563;
+}
+
+.ed-meta i {
+    width: 1rem;
+    color: var(--ed-green);
+    flex-shrink: 0;
+}
+
+.ed-description {
+    font-size: 0.875rem;
+    color: #6b7280;
+    line-height: 1.5;
+    margin-top: 0.25rem;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+}
+
+/* Fill bar */
+.fill-bar-wrap {
+    margin-top: auto;
+    padding-top: 0.75rem;
+}
+
+.fill-bar-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #6b7280;
+    margin-bottom: 0.3rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.fill-bar-track {
+    height: 8px;
+    background: #e5e7eb;
+    border-radius: 99px;
+    overflow: hidden;
+}
+
+.fill-bar-fill {
+    height: 100%;
+    border-radius: 99px;
+    transition: width 0.4s ease;
+}
+
+.fill-bar-fill[data-level="low"]  { background: var(--ed-green-light); }
+.fill-bar-fill[data-level="high"] { background: #f4a261; }
+.fill-bar-fill[data-level="full"] { background: #e63946; }
+
+.full-pill {
+    font-size: 0.7rem;
+    font-weight: 700;
+    background: #fee2e2;
+    color: #b91c1c;
+    padding: 0.15rem 0.5rem;
+    border-radius: 99px;
+    letter-spacing: 0.04em;
+}
+
+/* Buttons */
+.btn-join {
+    display: block;
+    width: 100%;
+    margin-top: 0.875rem;
+    padding: 0.625rem 1rem;
+    background: var(--ed-green);
+    color: white;
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-align: center;
+    border-radius: 0.5rem;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+@media (hover: hover) {
+    .btn-join:hover { background: var(--ed-green-dark); }
+}
+
+.btn-calendar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    width: 100%;
+    margin-top: 0.875rem;
+    padding: 0.625rem 1rem;
+    background: white;
+    color: var(--ed-green);
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-align: center;
+    border-radius: 0.5rem;
+    border: 2px solid var(--ed-green);
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+@media (hover: hover) {
+    .btn-calendar:hover {
+        background: var(--ed-green);
+        color: white;
+    }
+}
+
+.btn-disabled {
+    display: block;
+    width: 100%;
+    margin-top: 0.875rem;
+    padding: 0.625rem 1rem;
+    background: #e5e7eb;
+    color: #9ca3af;
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-align: center;
+    border-radius: 0.5rem;
+    border: none;
+    cursor: not-allowed;
+}
+
+/* Greyed-out state */
+.ed-card.greyed-out {
+    filter: grayscale(0.55);
+    opacity: 0.62;
+    pointer-events: none;
+}
+
+/* Enrolled banner on card */
+.enrolled-banner {
+    background: var(--ed-green-dark);
+    color: #d1fae5;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-align: center;
+    padding: 0.3rem 0.75rem;
+}
+</style>
+
+<div class="ed-header">
+    <div class="max-w-7xl mx-auto">
+        <div class="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+                <h1 class="text-2xl font-bold flex items-center gap-2">
+                    🌍 Earth Day Mini-PL Workshops
+                </h1>
+                <p class="mt-1 text-green-100 text-sm">
+                    Wednesday, April 22 &nbsp;·&nbsp; 3:40 – 4:25 PM &nbsp;·&nbsp; Choose one workshop to attend
+                </p>
+            </div>
+            @if($userEnrollment)
+            <div class="bg-white/15 rounded-lg px-4 py-2 text-sm font-medium text-white">
+                ✓ Registered: <span class="font-bold">{{ $userEnrollment->workshop->title }}</span>
+            </div>
+            @endif
+        </div>
+    </div>
+</div>
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+    {{-- Flash messages --}}
+    @if(session('success'))
+    <div class="mb-6 p-4 bg-green-50 border border-green-200 text-green-800 rounded-lg font-medium text-sm">
+        {{ session('success') }}
+    </div>
+    @endif
+    @if(session('error'))
+    <div class="mb-6 p-4 bg-red-50 border border-red-200 text-red-800 rounded-lg font-medium text-sm">
+        {{ session('error') }}
+    </div>
+    @endif
+
+    @if($workshops->isEmpty())
+    <div class="text-center py-16 text-gray-500">
+        <div class="text-5xl mb-3">🌱</div>
+        <p class="font-medium">Workshops will be available soon. Check back later!</p>
+    </div>
+    @else
+    <div class="ed-grid">
+        @foreach($workshops as $workshop)
+            @php
+                $isEnrolledHere  = $userEnrollment && $userEnrollment->earth_day_workshop_id === $workshop->id;
+                $hasEnrolled     = $userEnrollment !== null;
+                $greyedOut       = $hasEnrolled && !$isEnrolledHere;
+                $level           = $workshop->fill_percentage >= 100 ? 'full' : ($workshop->fill_percentage >= 67 ? 'high' : 'low');
+            @endphp
+
+            <div class="ed-card {{ $greyedOut ? 'greyed-out' : '' }}">
+
+                @if($isEnrolledHere)
+                <div class="enrolled-banner">✓ YOUR WORKSHOP</div>
+                @endif
+
+                <div class="ed-card-header">
+                    <h3>{{ $workshop->title }}</h3>
+                    @if($workshop->presenter)
+                    <p class="text-green-100 text-sm">{{ $workshop->presenter }}</p>
+                    @endif
+                </div>
+
+                <div class="ed-card-body">
+
+                    @if($workshop->location)
+                    <div class="ed-meta">
+                        <i class="fas fa-map-marker-alt"></i>
+                        <span>{{ $workshop->location }}</span>
+                    </div>
+                    @endif
+
+                    <div class="ed-meta">
+                        <i class="fas fa-clock"></i>
+                        <span>{{ \Carbon\Carbon::parse($workshop->start_time)->format('g:i A') }} – {{ \Carbon\Carbon::parse($workshop->end_time)->format('g:i A') }}</span>
+                    </div>
+
+                    @if($workshop->description)
+                    <p class="ed-description">{{ $workshop->description }}</p>
+                    @endif
+
+                    {{-- Fill bar --}}
+                    <div class="fill-bar-wrap">
+                        <div class="fill-bar-label">
+                            <span>Availability</span>
+                            @if($workshop->isFull())
+                            <span class="full-pill">Full</span>
+                            @endif
+                        </div>
+                        <div class="fill-bar-track">
+                            <div class="fill-bar-fill" style="width: {{ $workshop->fill_percentage }}%" data-level="{{ $level }}"></div>
+                        </div>
+                    </div>
+
+                    {{-- Action --}}
+                    @if($isEnrolledHere)
+                        <a href="{{ $workshop->google_calendar_url }}" target="_blank" rel="noopener" class="btn-calendar">
+                            <i class="fas fa-calendar-plus"></i> Add to Google Calendar
+                        </a>
+                    @elseif($hasEnrolled || $workshop->isFull())
+                        <button class="btn-disabled" disabled>
+                            {{ $workshop->isFull() ? 'Full' : 'Join Workshop' }}
+                        </button>
+                    @else
+                        <form method="POST" action="{{ route('earth-day.enroll', $workshop) }}">
+                            @csrf
+                            <button type="submit" class="btn-join">Join Workshop</button>
+                        </form>
+                    @endif
+
+                </div>
+            </div>
+        @endforeach
+    </div>
+    @endif
+
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -207,6 +207,10 @@
                                class="text-white hover:text-gray-200 {{ request()->routeIs('admin.ccl.*') ? 'font-medium underline underline-offset-4' : '' }}">
                                 Collaborative Community Learning
                             </a>
+                            <a href="{{ route('admin.earth-day.index') }}"
+                               class="text-white hover:text-gray-200 {{ request()->routeIs('admin.earth-day.*') ? 'font-medium underline underline-offset-4' : '' }}">
+                                Earth Day PL
+                            </a>
                             <a href="{{ route('admin.schedule.index') }}"
                                class="text-white hover:text-gray-200 {{ request()->routeIs('admin.schedule.*') ? 'font-medium underline underline-offset-4' : '' }}">
                                 Schedule
@@ -252,6 +256,10 @@
                         <a href="{{ route('admin.ccl.index') }}"
                            class="block px-3 py-2 text-base font-medium text-white hover:text-gray-200 hover:bg-white/10 rounded-md {{ request()->routeIs('admin.ccl.*') ? 'bg-white/10' : '' }}">
                             Collaborative Community Learning
+                        </a>
+                        <a href="{{ route('admin.earth-day.index') }}"
+                           class="block px-3 py-2 text-base font-medium text-white hover:text-gray-200 hover:bg-white/10 rounded-md {{ request()->routeIs('admin.earth-day.*') ? 'bg-white/10' : '' }}">
+                            Earth Day PL
                         </a>
                         <a href="{{ route('admin.schedule.index') }}"
                            class="block px-3 py-2 text-base font-medium text-white hover:text-gray-200 hover:bg-white/10 rounded-md {{ request()->routeIs('admin.schedule.*') ? 'bg-white/10' : '' }}">

--- a/resources/views/layouts/user.blade.php
+++ b/resources/views/layouts/user.blade.php
@@ -222,11 +222,12 @@
                 min-height: 44px;
             }
 
-            /* Sub navigation on mobile */
+            /* Sub navigation on mobile - same-size buttons, no wrapping */
             .sub-nav .sub-nav-item {
                 padding: 0.625rem 0.875rem;
                 font-size: 0.875rem;
                 min-height: 40px;
+                white-space: nowrap;
             }
 
             /* Better spacing for content areas */
@@ -358,6 +359,14 @@
                         </a>
                         @endif
 
+                        <!-- Earth Day -->
+                        @if($earthDayActive ?? false)
+                        <a href="{{ route('earth-day.index') }}"
+                           class="main-nav-item {{ request()->routeIs('earth-day.*') ? 'active' : '' }}">
+                            🌍 Earth Day
+                        </a>
+                        @endif
+
                         <!-- PL Wednesday -->
                         @if($plWednesdayActive ?? false)
                         <a href="{{ route('pl-wednesday.index') }}"
@@ -434,7 +443,7 @@
                             </a>
                             @if($cclActive ?? false)
                             <a href="{{ route('spring.ccl') }}" class="block px-3 py-2 text-sm text-tlc-cream hover:text-tlc-gold {{ request()->routeIs('spring.ccl') ? 'text-tlc-gold font-semibold' : '' }}">
-                                Collaborative Community Learning
+                                <span class="sm:hidden">CCL</span><span class="hidden sm:inline">Collaborative Community Learning</span>
                             </a>
                             @endif
                             @if(isset($archivedSpringPDDays) && $archivedSpringPDDays->count() > 0)
@@ -453,6 +462,14 @@
                     <a href="{{ route('spring.nts') }}"
                        class="block px-3 py-2 text-base font-medium text-tlc-cream hover:text-tlc-navy rounded-md transition-colors {{ request()->routeIs('spring.nts*') ? 'text-tlc-navy' : '' }}" style="{{ request()->routeIs('spring.nts*') ? 'background-color: var(--tlc-gold);' : '' }}">
                         NTS Sessions
+                    </a>
+                    @endif
+
+                    <!-- Earth Day -->
+                    @if($earthDayActive ?? false)
+                    <a href="{{ route('earth-day.index') }}"
+                       class="block px-3 py-2 text-base font-medium text-tlc-cream hover:text-tlc-navy rounded-md transition-colors {{ request()->routeIs('earth-day.*') ? 'text-tlc-navy' : '' }}" style="{{ request()->routeIs('earth-day.*') ? 'background-color: var(--tlc-gold);' : '' }}">
+                        🌍 Earth Day
                     </a>
                     @endif
 
@@ -533,7 +550,7 @@
                 @if($cclActive ?? false)
                 <a href="{{ route('spring.ccl') }}"
                    class="sub-nav-item {{ request()->routeIs('spring.ccl') ? 'active' : '' }}">
-                    Collaborative Community Learning
+                    <span class="sm:hidden">CCL</span><span class="hidden sm:inline">Collaborative Community Learning</span>
                 </a>
                 @endif
                 <a href="{{ route('spring.nts') }}"
@@ -558,7 +575,7 @@
                 @if($cclActive ?? false)
                 <a href="{{ route('spring.ccl') }}"
                    class="sub-nav-item {{ request()->routeIs('spring.ccl') ? 'active' : '' }}">
-                    Collaborative Community Learning
+                    <span class="sm:hidden">CCL</span><span class="hidden sm:inline">Collaborative Community Learning</span>
                 </a>
                 @endif
                 @if(isset($archivedSpringPDDays) && $archivedSpringPDDays->count() > 0)

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ use App\Http\Controllers\Admin\PDDayController;
 use App\Http\Controllers\Admin\AdminAuthController;
 use App\Http\Controllers\Auth\GoogleController;
 use App\Http\Controllers\ClaudeSettingsController;
+use App\Http\Controllers\EarthDayController;
+use App\Http\Controllers\Admin\EarthDayController as AdminEarthDayController;
 use App\Models\PDDay;
 use Illuminate\Support\Facades\Route;
 
@@ -133,6 +135,12 @@ Route::middleware(['user.only'])->group(function () {
     Route::get('/professional-learning', [PLWednesdayController::class, 'index'])->name('pl-wednesday.index');
     Route::get('/professional-learning/{session}', [PLWednesdayController::class, 'show'])->name('pl-wednesday.show');
     
+    // Earth Day Mini-PL Workshops
+    Route::prefix('earth-day')->name('earth-day.')->group(function () {
+        Route::get('/', [EarthDayController::class, 'index'])->name('index');
+        Route::post('/{workshop}/enroll', [EarthDayController::class, 'enroll'])->name('enroll');
+    });
+
     // Archive (hidden, accessible via direct URL)
     Route::get('/archive', [ScheduleController::class, 'archive'])->name('archive.index');
     
@@ -148,11 +156,16 @@ Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(fun
     
     // User Management
     Route::get('/users', [AdminController::class, 'users'])->name('users.index');
+    Route::get('/users/create', [AdminController::class, 'createUser'])->name('users.create');
+    Route::post('/users', [AdminController::class, 'storeUser'])->name('users.store');
+    Route::get('/users/{user}/edit', [AdminController::class, 'editUser'])->name('users.edit');
+    Route::put('/users/{user}', [AdminController::class, 'updateUser'])->name('users.update');
     Route::get('/users/{user}', [AdminController::class, 'showUser'])->name('users.show');
     Route::post('/users/{user}/toggle-admin', [AdminController::class, 'toggleAdmin'])->name('users.toggle-admin');
     Route::post('/users/{user}/update-password', [AdminController::class, 'updatePassword'])->name('users.update-password');
     
     // Wellness Sessions Management
+    Route::get('/wellness/export', [WellnessSessionController::class, 'exportAll'])->name('wellness.export');
     Route::resource('wellness', WellnessSessionController::class);
     Route::get('/wellness/{wellness}/export-participants', [WellnessSessionController::class, 'exportParticipants'])->name('wellness.export-participants');
     Route::post('/wellness/{wellness}/toggle-status', [WellnessSessionController::class, 'toggleStatus'])->name('wellness.toggle-status');
@@ -182,6 +195,7 @@ Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(fun
     Route::resource('pl-wednesday', AdminPLWednesdayController::class);
     
     // CCL (Collaborative Community Learning Sessions) Management
+    Route::get('/ccl/export', [AdminCCLController::class, 'export'])->name('ccl.export');
     Route::post('/ccl/toggle-active', [AdminCCLController::class, 'toggleActive'])->name('ccl.toggle-active');
     Route::post('/ccl/{ccl}/toggle-status', [AdminCCLController::class, 'toggleSessionStatus'])->name('ccl.toggle-status');
     Route::post('/ccl/{ccl}/remove-enrollment', [AdminCCLController::class, 'removeEnrollment'])->name('ccl.remove-enrollment');
@@ -196,6 +210,13 @@ Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(fun
     Route::get('/reports/user-activity', [ReportsController::class, 'userActivity'])->name('reports.user-activity');
     Route::get('/reports/ccl-enrollments', [ReportsController::class, 'cclEnrollments'])->name('reports.ccl-enrollments');
     Route::get('/reports/session-participant-lists', [ReportsController::class, 'sessionParticipantLists'])->name('reports.session-participant-lists');
+
+    // Earth Day PL Management
+    Route::get('/earth-day/export', [AdminEarthDayController::class, 'export'])->name('earth-day.export');
+    Route::post('/earth-day/toggle-active', [AdminEarthDayController::class, 'toggleActive'])->name('earth-day.toggle-active');
+    Route::post('/earth-day/{earthDay}/toggle-status', [AdminEarthDayController::class, 'toggleStatus'])->name('earth-day.toggle-status');
+    Route::post('/earth-day/{earthDay}/remove-enrollment', [AdminEarthDayController::class, 'removeEnrollment'])->name('earth-day.remove-enrollment');
+    Route::resource('earth-day', AdminEarthDayController::class);
 
     // Feature Toggles
     Route::post('/toggle-wellness', [AdminController::class, 'toggleWellness'])->name('toggle-wellness');


### PR DESCRIPTION
## Summary

- Adds a new **Earth Day** top-level tab for April 22 where AES staff browse 15 workshops and register for exactly one
- Once a user joins, all other workshop cards grey out and become unclickable; their card gains an **Add to Google Calendar** button
- No unjoin for users — they're locked in; admins can remove enrollments via the admin panel
- Fixed capacity of 15 per workshop with a visual fill bar (no numbers shown)

## What's included

- **3 migrations**: `earth_day_settings`, `earth_day_workshops`, `earth_day_enrollments`
- **3 models**: `EarthDayWorkshop` (CAPACITY=15 constant, fill bar %, Google Calendar URL), `EarthDaySetting`, `EarthDayEnrollment`
- **User controller**: `EarthDayController` — index + enroll (DB transaction + lock for race safety)
- **Admin controller**: `Admin\EarthDayController` — full CRUD, feature toggle, remove enrollment, CSV export
- **Views**: `earth-day/index` (user), `admin/earth-day/{index,show,create,edit}`
- **Nav**: 🌍 Earth Day tab in user layout; "Earth Day PL" link in admin layout + dashboard
- **AppServiceProvider**: `earthDayActive` shared globally so tab shows on all pages
- **My PL**: `EarthDayWorkshop` added to group map and print transcript (0.75 contact hrs)

## Test plan

- [ ] Admin creates workshops at `/admin/earth-day/create`
- [ ] Staff visits `/earth-day` → sees workshop cards with fill bars
- [ ] Staff joins a workshop → that card shows "Add to Google Calendar", all others grey out and are unclickable
- [ ] Second join attempt returns error "You have already chosen a workshop"
- [ ] Full workshop shows red fill bar + disabled "Full" button
- [ ] Admin views participants at `/admin/earth-day/{id}`
- [ ] Admin removes a participant → enrollment count decrements
- [ ] Admin toggles feature OFF → tab hidden from nav, `/earth-day` returns 404
- [ ] `/my-pl` shows Earth Day workshop entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)